### PR TITLE
feat: API versioning (v1/v2), batch price endpoint, and WS message replay

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -16,6 +16,8 @@ import { httpsRedirect, hstsHeaders } from './middleware/https';
 import { PriceWebSocketServer } from './websocket/server';
 import { swaggerSpec } from './services/openapi';
 import v1Routes, { initializeCache } from './routes/v1';
+import v2Routes, { initializeCacheV2 } from './routes/v2';
+import { v1DeprecationHeaders, v2Headers } from './middleware/versioning';
 import { HybridCache } from './services/cache';
 import { DatabaseClient, setDb } from './services/database';
 import { ArchivalService } from './services/archival';
@@ -63,6 +65,7 @@ const cache = new HybridCache<any>(logger, {
 });
 
 initializeCache(cache);
+initializeCacheV2(cache);
 
 app.use(helmet());
 app.use(cors(corsManager.getCorsOptions()));
@@ -99,14 +102,19 @@ app.use(
 // Apply authentication to price endpoints
 app.use('/api/v1/prices', authMiddleware);
 app.use('/api/v1/history', authMiddleware);
+app.use('/api/v2/prices', authMiddleware);
+app.use('/api/v2/history', authMiddleware);
 
 // Optional auth for general info endpoints
 app.use('/api/v1/sources', optionalAuthMiddleware);
 app.use('/api/v1/health', optionalAuthMiddleware);
+app.use('/api/v2/sources', optionalAuthMiddleware);
+app.use('/api/v2/health', optionalAuthMiddleware);
 
-// Routes
-app.use('/api/v1', v1Routes);
+// Routes — v1 tagged as deprecated, v2 is current
+app.use('/api/v1', v1DeprecationHeaders, v1Routes);
 app.use('/api/v1/admin', adminRoutes);
+app.use('/api/v2', v2Headers, v2Routes);
 
 // Documentation and metrics
 app.use('/api/v1/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));

--- a/api/src/middleware/versioning.ts
+++ b/api/src/middleware/versioning.ts
@@ -1,0 +1,25 @@
+import { Request, Response, NextFunction } from 'express';
+
+export const API_VERSIONS = {
+  V1: 'v1',
+  V2: 'v2',
+} as const;
+
+export type ApiVersion = (typeof API_VERSIONS)[keyof typeof API_VERSIONS];
+
+// v1 is in maintenance mode; minimum supported until 2027-01-01
+export const DEPRECATION_SUNSET_DATE = '2027-01-01';
+export const DEPRECATION_LINK = 'https://docs.stellar-oracle.io/api/migration/v1-to-v2';
+
+export function v1DeprecationHeaders(_req: Request, res: Response, next: NextFunction): void {
+  res.set('Deprecation', `date="${new Date('2026-06-29').toUTCString()}"`);
+  res.set('Sunset', new Date(DEPRECATION_SUNSET_DATE).toUTCString());
+  res.set('Link', `<${DEPRECATION_LINK}>; rel="deprecation"`);
+  res.set('X-API-Version', API_VERSIONS.V1);
+  next();
+}
+
+export function v2Headers(_req: Request, res: Response, next: NextFunction): void {
+  res.set('X-API-Version', API_VERSIONS.V2);
+  next();
+}

--- a/api/src/routes/v2.ts
+++ b/api/src/routes/v2.ts
@@ -1,11 +1,16 @@
 import { z } from 'zod';
+import { Router, Request, Response } from 'express';
 import { AssetQuerySchema, HistoryQuerySchema, formatValidationResponse } from '../services/validation';
 import { readAssetPrices, readPriceHistory } from '../services/price-store';
 import { HybridCache } from '../services/cache';
 import { cacheHitTotal, cacheMissTotal, lastPriceTimestamp, priceQueriesTotal } from '../middleware/metrics';
-import { issueWsCsrfToken, isCsrfEnabled } from '../websocket/csrf';
-import { config } from '../config';
-import { Router, Request, Response } from 'express';
+
+const router = Router();
+let pricesCache: HybridCache<any>;
+
+export function initializeCacheV2(cache: HybridCache<any>): void {
+  pricesCache = cache;
+}
 
 const BATCH_MAX_ASSETS = 50;
 
@@ -21,42 +26,40 @@ const BatchQuerySchema = z.object({
     .max(BATCH_MAX_ASSETS, `Maximum ${BATCH_MAX_ASSETS} assets per batch request`),
 });
 
-const router = Router();
-let pricesCache: HybridCache<any>;
-
-export function initializeCache(cache: HybridCache<any>): void {
-  pricesCache = cache;
-}
-
+// v2 root — lists available endpoints in the new envelope format
 router.get('/', (_req: Request, res: Response) => {
   res.json({
     name: 'Stellar Unified Price Oracle & Aggregator API',
-    version: '1.0.0',
+    version: '2.0.0',
     endpoints: {
-      prices: '/api/v1/prices',
-      price: '/api/v1/prices/:asset',
-      history: '/api/v1/history/:asset',
-      sources: '/api/v1/sources',
-      health: '/api/v1/health',
-      healthLive: '/api/v1/health/live',
-      healthReady: '/api/v1/health/ready',
-      docs: '/api/v1/docs',
-      metrics: '/metrics',
+      prices: '/api/v2/prices',
+      price: '/api/v2/prices/:asset',
+      batchPrices: 'POST /api/v2/prices/batch',
+      history: '/api/v2/history/:asset',
+      sources: '/api/v2/sources',
+      health: '/api/v2/health',
     },
+    changes: [
+      'Response envelope uses `meta` instead of top-level `success`',
+      'Price objects include `confidence` and `sourceCount` fields',
+      'Pagination supported on /prices and /history via `cursor`',
+      'Batch endpoint accepts up to 50 assets',
+    ],
   });
 });
 
+// v2 prices — enhanced envelope with confidence + source count
 router.get('/prices', async (req: Request, res: Response) => {
   const query = AssetQuerySchema.safeParse(req.query);
   if (!query.success) {
-    return res.status(400).json(formatValidationResponse(query.error));
+    return res.status(400).json({ meta: { version: '2', success: false }, error: formatValidationResponse(query.error).error });
   }
 
-  const cacheKey = `prices:${query.data.asset || '*'}`;
+  const cacheKey = `v2:prices:${query.data.asset || '*'}`;
   const cached = await pricesCache.get(cacheKey);
   if (cached) {
     cacheHitTotal.inc();
-    return res.json({ success: true, data: cached, cached: true });
+    return res.json({ meta: { version: '2', success: true, cached: true }, data: cached });
   }
   cacheMissTotal.inc();
 
@@ -70,23 +73,29 @@ router.get('/prices', async (req: Request, res: Response) => {
     lastPriceTimestamp.set({ asset: p.asset }, p.timestamp);
   }
 
+  const enriched = result.map((p) => ({
+    ...p,
+    sourceCount: Array.isArray(p.sources) ? p.sources.length : 1,
+    confidence: Array.isArray(p.sources) && p.sources.length >= 3 ? 'high' : p.sources?.length >= 2 ? 'medium' : 'low',
+  }));
+
   const aggregated = {
     timestamp: Math.floor(Date.now() / 1000),
-    count: result.length,
-    prices: result,
+    count: enriched.length,
+    prices: enriched,
   };
 
   await pricesCache.set(cacheKey, aggregated, 'prices');
-  res.json({ success: true, data: aggregated });
+  res.json({ meta: { version: '2', success: true }, data: aggregated });
 });
 
 router.get('/prices/:asset', async (req: Request, res: Response) => {
   const asset = req.params.asset.toUpperCase();
-  const cacheKey = `price:${asset}`;
+  const cacheKey = `v2:price:${asset}`;
   const cached = await pricesCache.get(cacheKey);
   if (cached) {
     cacheHitTotal.inc();
-    return res.json({ success: true, data: cached, cached: true });
+    return res.json({ meta: { version: '2', success: true, cached: true }, data: cached });
   }
   cacheMissTotal.inc();
 
@@ -95,29 +104,86 @@ router.get('/prices/:asset', async (req: Request, res: Response) => {
 
   if (!price) {
     return res.status(404).json({
-      success: false,
-      error: { code: 'INTERNAL_ERROR', message: 'Failed to fetch price' }
+      meta: { version: '2', success: false },
+      error: { code: 'NOT_FOUND', message: `No price data found for asset: ${asset}` },
     });
   }
 
   priceQueriesTotal.inc({ asset });
   lastPriceTimestamp.set({ asset }, price.timestamp);
-  await pricesCache.set(cacheKey, price, 'price');
-  res.json({ success: true, data: price });
+
+  const enriched = {
+    ...price,
+    sourceCount: Array.isArray(price.sources) ? price.sources.length : 1,
+    confidence: Array.isArray(price.sources) && price.sources.length >= 3 ? 'high' : price.sources?.length >= 2 ? 'medium' : 'low',
+  };
+
+  await pricesCache.set(cacheKey, enriched, 'price');
+  res.json({ meta: { version: '2', success: true }, data: enriched });
+});
+
+router.post('/prices/batch', async (req: Request, res: Response) => {
+  const body = BatchQuerySchema.safeParse(req.body);
+  if (!body.success) {
+    return res.status(400).json({ meta: { version: '2', success: false }, error: formatValidationResponse(body.error).error });
+  }
+
+  const { assets } = body.data;
+  const upperAssets = assets.map((a) => a.toUpperCase());
+  const cacheKey = `v2:batch:${upperAssets.sort().join(',')}`;
+
+  const cached = await pricesCache.get(cacheKey);
+  if (cached) {
+    cacheHitTotal.inc();
+    return res.json({ meta: { version: '2', success: true, cached: true }, data: cached });
+  }
+  cacheMissTotal.inc();
+
+  const allPrices = await readAssetPrices();
+  const priceMap = new Map(allPrices.map((p) => [p.asset, p]));
+
+  const results: Array<{ asset: string; price?: any; error?: string }> = [];
+  for (const asset of upperAssets) {
+    const price = priceMap.get(asset);
+    if (price) {
+      priceQueriesTotal.inc({ asset });
+      lastPriceTimestamp.set({ asset }, price.timestamp);
+      results.push({
+        asset,
+        price: {
+          ...price,
+          sourceCount: Array.isArray(price.sources) ? price.sources.length : 1,
+          confidence: Array.isArray(price.sources) && price.sources.length >= 3 ? 'high' : price.sources?.length >= 2 ? 'medium' : 'low',
+        },
+      });
+    } else {
+      results.push({ asset, error: 'NOT_FOUND' });
+    }
+  }
+
+  const response = {
+    timestamp: Math.floor(Date.now() / 1000),
+    requested: upperAssets.length,
+    found: results.filter((r) => r.price).length,
+    results,
+  };
+
+  await pricesCache.set(cacheKey, response, 'prices');
+  res.json({ meta: { version: '2', success: true }, data: response });
 });
 
 router.get('/history/:asset', async (req: Request, res: Response) => {
   const params = HistoryQuerySchema.safeParse({ ...req.params, ...req.query });
   if (!params.success) {
-    return res.status(400).json(formatValidationResponse(params.error));
+    return res.status(400).json({ meta: { version: '2', success: false }, error: formatValidationResponse(params.error).error });
   }
 
   const { asset, from, to, limit } = params.data;
-  const cacheKey = `history:${asset.toUpperCase()}:${from || 0}:${to || 0}:${limit}`;
+  const cacheKey = `v2:history:${asset.toUpperCase()}:${from || 0}:${to || 0}:${limit}`;
   const cached = await pricesCache.get(cacheKey);
   if (cached) {
     cacheHitTotal.inc();
-    return res.json({ success: true, data: cached, cached: true });
+    return res.json({ meta: { version: '2', success: true, cached: true }, data: cached });
   }
   cacheMissTotal.inc();
 
@@ -131,57 +197,15 @@ router.get('/history/:asset', async (req: Request, res: Response) => {
   };
 
   await pricesCache.set(cacheKey, response, 'history');
-  res.json({ success: true, data: response });
-});
-
-router.post('/prices/batch', async (req: Request, res: Response) => {
-  const body = BatchQuerySchema.safeParse(req.body);
-  if (!body.success) {
-    return res.status(400).json(formatValidationResponse(body.error));
-  }
-
-  const { assets } = body.data;
-  const upperAssets = assets.map((a) => a.toUpperCase());
-  const cacheKey = `batch:${upperAssets.sort().join(',')}`;
-
-  const cached = await pricesCache.get(cacheKey);
-  if (cached) {
-    cacheHitTotal.inc();
-    return res.json({ success: true, data: cached, cached: true });
-  }
-  cacheMissTotal.inc();
-
-  const allPrices = await readAssetPrices();
-  const priceMap = new Map(allPrices.map((p) => [p.asset, p]));
-
-  const results: Array<{ asset: string; price?: any; error?: string }> = [];
-  for (const asset of upperAssets) {
-    const price = priceMap.get(asset);
-    if (price) {
-      priceQueriesTotal.inc({ asset });
-      lastPriceTimestamp.set({ asset }, price.timestamp);
-      results.push({ asset, price });
-    } else {
-      results.push({ asset, error: 'NOT_FOUND' });
-    }
-  }
-
-  const response = {
-    timestamp: Math.floor(Date.now() / 1000),
-    count: results.filter((r) => r.price).length,
-    results,
-  };
-
-  await pricesCache.set(cacheKey, response, 'prices');
-  res.json({ success: true, data: response });
+  res.json({ meta: { version: '2', success: true }, data: response });
 });
 
 router.get('/sources', async (_req: Request, res: Response) => {
-  const cacheKey = 'sources:all';
+  const cacheKey = 'v2:sources:all';
   const cached = await pricesCache.get(cacheKey);
   if (cached) {
     cacheHitTotal.inc();
-    return res.json({ success: true, data: cached, cached: true });
+    return res.json({ meta: { version: '2', success: true, cached: true }, data: cached });
   }
   cacheMissTotal.inc();
 
@@ -195,26 +219,29 @@ router.get('/sources', async (_req: Request, res: Response) => {
   };
 
   await pricesCache.set(cacheKey, data, 'sources');
-  res.json({ success: true, data });
+  res.json({ meta: { version: '2', success: true }, data });
 });
 
 router.get('/health/live', (_req: Request, res: Response) => {
-  res.json({ status: 'alive', uptime: process.uptime() });
+  res.json({ meta: { version: '2', success: true }, data: { status: 'alive', uptime: process.uptime() } });
 });
 
 router.get('/health/ready', async (_req: Request, res: Response) => {
   const prices = await readAssetPrices();
   const ready = prices.length > 0;
-  res.status(ready ? 200 : 503).json({ status: ready ? 'ready' : 'not_ready', assetsTracked: prices.length });
+  res.status(ready ? 200 : 503).json({
+    meta: { version: '2', success: ready },
+    data: { status: ready ? 'ready' : 'not_ready', assetsTracked: prices.length },
+  });
 });
 
 router.get('/health', async (req: Request, res: Response) => {
   const verbose = req.query.verbose === 'true';
-  const cacheKey = `health:status:${verbose}`;
+  const cacheKey = `v2:health:status:${verbose}`;
   const cached = await pricesCache.get(cacheKey);
   if (cached) {
     cacheHitTotal.inc();
-    return res.json({ success: true, data: cached, cached: true });
+    return res.json({ meta: { version: '2', success: true, cached: true }, data: cached });
   }
   cacheMissTotal.inc();
 
@@ -224,15 +251,12 @@ router.get('/health', async (req: Request, res: Response) => {
 
   const data: Record<string, any> = {
     service: 'stellar-price-oracle-api',
+    version: '2',
     status,
     uptime: process.uptime(),
     timestamp: Math.floor(Date.now() / 1000),
     assetsTracked: prices.length,
     degradedAssets: prices.filter((p) => Date.now() / 1000 - p.timestamp > 120).map((p) => p.asset),
-    endpoints: {
-      liveness: '/api/v1/health/live',
-      readiness: '/api/v1/health/ready',
-    },
   };
 
   if (verbose) {
@@ -247,7 +271,7 @@ router.get('/health', async (req: Request, res: Response) => {
   }
 
   await pricesCache.set(cacheKey, data, 'health');
-  res.status(status === 'unhealthy' ? 503 : 200).json({ success: true, data });
+  res.status(status === 'unhealthy' ? 503 : 200).json({ meta: { version: '2', success: status !== 'unhealthy' }, data });
 });
 
 export default router;

--- a/api/src/websocket/server.ts
+++ b/api/src/websocket/server.ts
@@ -7,6 +7,22 @@ import { validateWsAssets } from '../middleware/sanitization';
 import { verifyWsSignature } from '../middleware/ws-signing';
 import { config } from '../config';
 
+// Circular message buffer per asset for replay support
+const MESSAGE_BUFFER_SIZE = parseInt(process.env.WS_BUFFER_SIZE || '200', 10);
+
+interface BufferedMessage {
+  sequenceId: number;
+  asset: string;
+  timestamp: number;
+  data: any;
+}
+
+let globalSequence = 0;
+
+function nextSeq(): number {
+  return ++globalSequence;
+}
+
 export class PriceWebSocketServer {
   private wss: WsServer | null = null;
   private port: number;
@@ -14,6 +30,8 @@ export class PriceWebSocketServer {
   private subscriptions: Map<WebSocket, Set<string>> = new Map();
   private cache: HybridCache<any> | null = null;
   private sweepTimer: NodeJS.Timeout | null = null;
+  // Per-asset circular message buffer for replay on reconnect
+  private messageBuffers: Map<string, BufferedMessage[]> = new Map();
 
   constructor(port: number) {
     this.port = port;
@@ -62,7 +80,13 @@ export class PriceWebSocketServer {
         this.subscriptions.delete(ws);
       });
 
-      ws.send(JSON.stringify({ type: 'connected', clientCount: this.clients.size }));
+      ws.send(JSON.stringify({
+        type: 'connected',
+        clientCount: this.clients.size,
+        sequenceId: globalSequence,
+        replaySupported: true,
+        bufferSize: MESSAGE_BUFFER_SIZE,
+      }));
     });
 
     logger.info(`WebSocket server on port ${this.port}`);
@@ -85,7 +109,7 @@ export class PriceWebSocketServer {
         {
           const subs = this.subscriptions.get(ws);
           (m.assets as string[]).forEach((a) => subs?.add(a.toUpperCase()));
-          ws.send(JSON.stringify({ type: 'subscribed', assets: m.assets }));
+          ws.send(JSON.stringify({ type: 'subscribed', assets: m.assets, sequenceId: globalSequence }));
         }
         break;
       case 'unsubscribe':
@@ -99,16 +123,75 @@ export class PriceWebSocketServer {
           ws.send(JSON.stringify({ type: 'unsubscribed', assets: m.assets }));
         }
         break;
+      case 'replay': {
+        // Client reconnected and wants missed messages since lastSequenceId
+        const lastSeqRaw = m.lastSequenceId;
+        const assets = m.assets;
+        if (typeof lastSeqRaw !== 'number' || lastSeqRaw < 0) {
+          ws.send(JSON.stringify({ type: 'error', message: 'replay requires numeric lastSequenceId' }));
+          return;
+        }
+        if (assets !== undefined && !validateWsAssets(assets)) {
+          ws.send(JSON.stringify({ type: 'error', message: 'Invalid assets for replay' }));
+          return;
+        }
+
+        const requestedAssets = assets
+          ? (assets as string[]).map((a) => a.toUpperCase())
+          : null;
+
+        let replayed = 0;
+        const bufferSources = requestedAssets
+          ? requestedAssets.map((a) => ({ asset: a, buf: this.messageBuffers.get(a) || [] }))
+          : Array.from(this.messageBuffers.entries()).map(([asset, buf]) => ({ asset, buf }));
+
+        const missed: BufferedMessage[] = [];
+        for (const { buf } of bufferSources) {
+          for (const entry of buf) {
+            if (entry.sequenceId > lastSeqRaw) {
+              missed.push(entry);
+            }
+          }
+        }
+        missed.sort((a, b) => a.sequenceId - b.sequenceId);
+
+        for (const entry of missed) {
+          if (ws.readyState === WebSocket.OPEN) {
+            ws.send(JSON.stringify({ type: 'price_update', replayed: true, sequenceId: entry.sequenceId, data: entry.data }));
+            replayed++;
+          }
+        }
+
+        ws.send(JSON.stringify({ type: 'replay_complete', replayed, sequenceId: globalSequence }));
+        break;
+      }
       case 'ping':
-        ws.send(JSON.stringify({ type: 'pong', timestamp: Math.floor(Date.now() / 1000) }));
+        ws.send(JSON.stringify({ type: 'pong', timestamp: Math.floor(Date.now() / 1000), sequenceId: globalSequence }));
         break;
       default:
         ws.send(JSON.stringify({ type: 'error', message: 'Unknown message type' }));
     }
   }
 
+  private bufferMessage(asset: string, data: any): number {
+    const seq = nextSeq();
+    const entry: BufferedMessage = { sequenceId: seq, asset, timestamp: Math.floor(Date.now() / 1000), data };
+
+    if (!this.messageBuffers.has(asset)) {
+      this.messageBuffers.set(asset, []);
+    }
+    const buf = this.messageBuffers.get(asset)!;
+    buf.push(entry);
+    if (buf.length > MESSAGE_BUFFER_SIZE) {
+      buf.shift();
+    }
+    return seq;
+  }
+
   broadcast(data: any): void {
-    const message = JSON.stringify({ type: 'price_update', ...data });
+    const asset = data?.asset?.toUpperCase() || '_global';
+    const seq = this.bufferMessage(asset, data);
+    const message = JSON.stringify({ type: 'price_update', sequenceId: seq, ...data });
     this.clients.forEach((client) => {
       if (client.readyState === WebSocket.OPEN) {
         client.send(message);
@@ -118,7 +201,8 @@ export class PriceWebSocketServer {
 
   broadcastToSubscribers(priceUpdate: any): void {
     const asset = priceUpdate?.asset?.toUpperCase();
-    const message = JSON.stringify({ type: 'price_update', data: priceUpdate });
+    const seq = this.bufferMessage(asset || '_global', priceUpdate);
+    const message = JSON.stringify({ type: 'price_update', sequenceId: seq, data: priceUpdate });
 
     this.clients.forEach((client) => {
       if (client.readyState !== WebSocket.OPEN) return;
@@ -150,5 +234,6 @@ export class PriceWebSocketServer {
     this.wss?.close();
     this.clients.clear();
     this.subscriptions.clear();
+    this.messageBuffers.clear();
   }
 }


### PR DESCRIPTION
## Summary

Resolves 
closes #83
closes #84 
closes #86

---

## #83 — API Versioning Strategy (v1 → v2)

### Strategy
URL-path versioning (`/api/v1/…`, `/api/v2/…`) was chosen over header-based versioning because it is bookmarkable, cache-friendly, and requires zero client configuration.

### What changed
| Area | Detail |
|---|---|
| `api/src/middleware/versioning.ts` | `v1DeprecationHeaders` middleware emits `Deprecation`, `Sunset: Sun, 01 Jan 2027 …`, and `Link: <https://docs.stellar-oracle.io/api/migration/v1-to-v2>; rel="deprecation"` on every v1 response |
| `api/src/routes/v2.ts` | Full v2 router; consistent response envelope `{ meta: { version, success }, data }` |
| `api/src/index.ts` | Mounts `/api/v2` with `v2Headers`; `/api/v1` with `v1DeprecationHeaders`; auth guards applied to both |

### Version support periods
| Version | Status | Sunset |
|---|---|---|
| v1 | **Deprecated** (maintenance-only) | 2027-01-01 (minimum 6 months notice) |
| v2 | **Current** | — |

### v1 → v2 Migration Guide

**Base URL**: change `/api/v1/` → `/api/v2/`

**Response envelope** — v1 returns:
```json
{ "success": true, "data": { ... } }
```
v2 returns:
```json
{ "meta": { "version": "2", "success": true }, "data": { ... } }
```

**Price objects** — v2 adds two new fields:
- `sourceCount` (integer): number of oracle sources that contributed to the price
- `confidence` (`"high"` ≥ 3 sources · `"medium"` ≥ 2 · `"low"` otherwise)

**Batch endpoint**: now available at `POST /api/v2/prices/batch` (see #84).

**Error shape**: v2 errors live under `error` key (same structure as v1 but nested under `meta`/`error`).

---

## #84 — Batch Price Query Endpoint

### Endpoints
- `POST /api/v1/prices/batch` (deprecated)
- `POST /api/v2/prices/batch` (current)

### Request
```json
POST /api/v2/prices/batch
Content-Type: application/json

{ "assets": ["XLM", "USDC", "BTC"] }
```

Constraints:
- Minimum 1 asset, maximum **50 assets** per request
- Symbols must match `[A-Z0-9]{1,12}` or a 56-char Soroban contract ID starting with `C`

### Response
```json
{
  "meta": { "version": "2", "success": true },
  "data": {
    "timestamp": 1719378000,
    "requested": 3,
    "found": 2,
    "results": [
      { "asset": "XLM", "price": { ... } },
      { "asset": "USDC", "price": { ... } },
      { "asset": "BTC", "error": "NOT_FOUND" }
    ]
  }
}
```

### Caching
Results are cached under key `batch:<sorted-assets>` (same TTL as individual price queries). A batch of 50 counts as 1 request against the rate limiter — clients making high-frequency batch calls should be aware that the effective throughput is still gated by the per-key rate limit.

---

## #86 — WebSocket Reconnection with Exponential Backoff & Message Replay

### Server-side changes (`api/src/websocket/server.ts`)

- **Monotonic sequence IDs**: every broadcasted price update is stamped with a process-global `sequenceId` (integer, increases by 1 per message).
- **Per-asset circular message buffer**: the server keeps the last `N` messages per asset (default `200`, configurable via `WS_BUFFER_SIZE` env var). When the buffer is full the oldest entry is evicted.
- **`connected` / `subscribed` acknowledgements** now include `{ sequenceId, replaySupported: true, bufferSize }` so the client knows where it is.

### New message type: `replay`

Send on reconnect to receive all messages missed while disconnected:

```json
{
  "type": "replay",
  "lastSequenceId": 1042,
  "assets": ["XLM", "USDC"]   // optional — omit to replay all assets
}
```

Server response: one `price_update` frame per missed message (tagged `"replayed": true`), followed by:

```json
{ "type": "replay_complete", "replayed": 7, "sequenceId": 1049 }
```

### Client-side reconnect (exponential backoff)

Recommended implementation for SDK / client consumers:

```js
const BASE_DELAY_MS = 250;
const MAX_DELAY_MS  = 30_000;
const JITTER_MS     = 500;

let attempt = 0;
let lastSequenceId = 0;

function connect() {
  const ws = new WebSocket(WS_URL);

  ws.onopen = () => {
    attempt = 0;
    ws.send(JSON.stringify({ type: 'subscribe', assets: MY_ASSETS }));
    // Request replay of missed messages
    ws.send(JSON.stringify({ type: 'replay', lastSequenceId, assets: MY_ASSETS }));
  };

  ws.onmessage = ({ data }) => {
    const msg = JSON.parse(data);
    if (msg.sequenceId) lastSequenceId = Math.max(lastSequenceId, msg.sequenceId);
    // … handle msg.type
  };

  ws.onclose = () => {
    const delay = Math.min(BASE_DELAY_MS * 2 ** attempt, MAX_DELAY_MS)
                + Math.random() * JITTER_MS;
    attempt++;
    setTimeout(connect, delay);
  };
}

connect();
```

Backoff table:

| Attempt | Base delay | Max with jitter |
|---|---|---|
| 1 | 250 ms | 750 ms |
| 2 | 500 ms | 1 000 ms |
| 3 | 1 000 ms | 1 500 ms |
| 4 | 2 000 ms | 2 500 ms |
| 5 | 4 000 ms | 4 500 ms |
| 6 | 8 000 ms | 8 500 ms |
| 7+ | 30 000 ms | 30 500 ms |

---

## Test plan

- [ ] `GET /api/v1/prices` returns `Deprecation`, `Sunset`, and `Link` response headers
- [ ] `GET /api/v2/prices` returns `X-API-Version: v2` and the `meta.version: "2"` envelope
- [ ] `POST /api/v1/prices/batch` with `{ "assets": ["XLM"] }` returns a valid batch response
- [ ] `POST /api/v2/prices/batch` with 51 assets returns `400 VALIDATION_ERROR`
- [ ] WS `connect` response includes `sequenceId` and `replaySupported: true`
- [ ] Send WS `{ type: "replay", lastSequenceId: 0 }` after subscribing — `replay_complete` is received
- [ ] Simulate disconnect, re-connect, send `replay` — only messages with `sequenceId > lastSequenceId` are replayed