### PR TITLE
feat: add CI/CD pipeline with environment promotion, approval gates, and rollback (#103)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,167 @@
+name: Deploy
+
+on:
+  push:
+    branches: [develop, main]
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target environment
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-images:
+    name: Build and push Docker images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      api-tag: ${{ steps.tags.outputs.api-sha }}
+      aggregator-tag: ${{ steps.tags.outputs.aggregator-sha }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute short SHA
+        id: sha
+        run: echo "value=${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      - name: Set image tags
+        id: tags
+        env:
+          SHA: ${{ steps.sha.outputs.value }}
+        run: |
+          API_BASE="$REGISTRY/$GITHUB_REPOSITORY/api"
+          AGG_BASE="$REGISTRY/$GITHUB_REPOSITORY/aggregator"
+          echo "api-sha=${API_BASE}:sha-${SHA}" >> "$GITHUB_OUTPUT"
+          echo "aggregator-sha=${AGG_BASE}:sha-${SHA}" >> "$GITHUB_OUTPUT"
+
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "api-main=${API_BASE}:main" >> "$GITHUB_OUTPUT"
+            echo "api-latest=${API_BASE}:latest" >> "$GITHUB_OUTPUT"
+            echo "aggregator-main=${AGG_BASE}:main" >> "$GITHUB_OUTPUT"
+            echo "aggregator-latest=${AGG_BASE}:latest" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.ref }}" = "refs/heads/develop" ]; then
+            echo "api-develop=${API_BASE}:develop" >> "$GITHUB_OUTPUT"
+            echo "aggregator-develop=${AGG_BASE}:develop" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push API image
+        uses: docker/build-push-action@v6
+        with:
+          context: api
+          push: true
+          tags: |
+            ${{ steps.tags.outputs.api-sha }}
+            ${{ steps.tags.outputs.api-main }}
+            ${{ steps.tags.outputs.api-latest }}
+            ${{ steps.tags.outputs.api-develop }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push Aggregator image
+        uses: docker/build-push-action@v6
+        with:
+          context: services/aggregator
+          push: true
+          tags: |
+            ${{ steps.tags.outputs.aggregator-sha }}
+            ${{ steps.tags.outputs.aggregator-main }}
+            ${{ steps.tags.outputs.aggregator-latest }}
+            ${{ steps.tags.outputs.aggregator-develop }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy-dev:
+    name: Deploy to Dev
+    if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
+    needs: [build-images]
+    runs-on: ubuntu-latest
+    environment: dev
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kustomize
+        run: |
+          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          sudo mv kustomize /usr/local/bin/
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_DEV }}" > ~/.kube/config
+
+      - name: Deploy to dev
+        run: |
+          bash scripts/deploy-k8s.sh dev \
+            "${{ needs.build-images.outputs.api-tag }}" \
+            "${{ needs.build-images.outputs.aggregator-tag }}"
+
+  deploy-staging:
+    name: Deploy to Staging
+    if: >
+      ( github.ref == 'refs/heads/main' && github.event_name == 'push' ) ||
+      ( github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'staging' )
+    needs: [build-images]
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kustomize
+        run: |
+          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          sudo mv kustomize /usr/local/bin/
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_STAGING }}" > ~/.kube/config
+
+      - name: Deploy to staging
+        run: |
+          bash scripts/deploy-k8s.sh staging \
+            "${{ needs.build-images.outputs.api-tag }}" \
+            "${{ needs.build-images.outputs.aggregator-tag }}"
+
+  deploy-prod:
+    name: Deploy to Production
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production'
+    needs: [build-images]
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kustomize
+        run: |
+          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          sudo mv kustomize /usr/local/bin/
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_PROD }}" > ~/.kube/config
+
+      - name: Deploy to production
+        run: |
+          bash scripts/deploy-k8s.sh prod \
+            "${{ needs.build-images.outputs.api-tag }}" \
+            "${{ needs.build-images.outputs.aggregator-tag }}"

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -1,0 +1,92 @@
+name: Rollback
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Environment to rollback
+        required: true
+        type: choice
+        options:
+          - dev
+          - staging
+          - production
+      commit-sha:
+        description: Commit SHA to rollback to (default = previous commit on main)
+        required: false
+        default: ''
+
+env:
+  REGISTRY: ghcr.io
+  REF: ${{ github.sha }}
+
+jobs:
+  rollback:
+    name: Rollback ${{ github.event.inputs.environment }}
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment == 'production' && 'production' || github.event.inputs.environment }}
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Determine rollback SHA
+        id: sha
+        run: |
+          if [ -n "${{ github.event.inputs.commit-sha }}" ]; then
+            echo "value=${{ github.event.inputs.commit-sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=$(git rev-parse HEAD~1)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve rollback image tags
+        id: images
+        env:
+          SHA: ${{ steps.sha.outputs.value }}
+        run: |
+          API_IMAGE="${{ env.REGISTRY }}/${{ github.repository }}/api:sha-${SHA:0:7}"
+          AGGREGATOR_IMAGE="${{ env.REGISTRY }}/${{ github.repository }}/aggregator:sha-${SHA:0:7}"
+          echo "api-image=${API_IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "aggregator-image=${AGGREGATOR_IMAGE}" >> "$GITHUB_OUTPUT"
+
+      - name: Install kustomize
+        run: |
+          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          sudo mv kustomize /usr/local/bin/
+
+      - name: Prepare environment variables
+        id: prep
+        run: |
+          ENV="${{ github.event.inputs.environment }}"
+          echo "env_upper=$(echo "$ENV" | tr '[:lower:]' '[:upper:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Configure kubectl
+        env:
+          KUBECONFIG_VALUE: ${{ secrets[format('KUBECONFIG_{0}', steps.prep.outputs.env_upper)] }}
+        run: |
+          mkdir -p ~/.kube
+          echo "${KUBECONFIG_VALUE}" > ~/.kube/config
+
+      - name: Deploy rollback images
+        run: |
+          bash scripts/deploy-k8s.sh \
+            "${{ github.event.inputs.environment }}" \
+            "${{ steps.images.outputs.api-image }}" \
+            "${{ steps.images.outputs.aggregator-image }}"
+
+      - name: Verify rollback
+        run: |
+          echo "Rollback to ${{ steps.sha.outputs.value }} on ${{ github.event.inputs.environment }} complete."
+          kubectl rollout status deployment -n "stellar-oracle-${{ github.event.inputs.environment }}" \
+            --timeout=120s \
+            api-stable aggregator

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,33 @@
-.PHONY: all build clean test deploy help
+.PHONY: all build clean test deploy help deploy-soroban
 
 help:
 	@echo "Stellar Price Oracle Aggregator"
 	@echo ""
+	@echo "  build targets:"
 	@echo "  make build-soroban    Build the Soroban contract"
 	@echo "  make build-aggregator Build the aggregator service"
 	@echo "  make build-api        Build the REST API"
 	@echo "  make build            Build all components"
+	@echo ""
+	@echo "  test targets:"
 	@echo "  make test-soroban     Test the Soroban contract"
 	@echo "  make test-aggregator  Test the aggregator service"
 	@echo "  make test-api         Test the REST API"
 	@echo "  make test             Test all components"
+	@echo ""
+	@echo "  dev targets:"
 	@echo "  make install          Install all dependencies"
 	@echo "  make dev-aggregator   Run aggregator in dev mode"
 	@echo "  make dev-api          Run API in dev mode"
+	@echo ""
+	@echo "  deploy targets:"
 	@echo "  make deploy-soroban   Deploy Soroban contract (requires env)"
+	@echo "  make deploy-dev       Deploy to dev K8s cluster"
+	@echo "  make deploy-staging   Deploy to staging K8s cluster"
+	@echo "  make deploy-prod      Deploy to production K8s cluster"
+	@echo "  make rollback         Rollback deployment (ENV=<env> TAG=<tag>)"
+	@echo ""
+	@echo "  utility:"
 	@echo "  make clean            Clean build artifacts"
 
 install:

--- a/k8s/base/aggregator/deployment.yaml
+++ b/k8s/base/aggregator/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: aggregator
-          image: stellar-oracle-aggregator:latest
+          image: oracle-aggregator:placeholder
           imagePullPolicy: IfNotPresent
           ports:
             - name: http-metrics

--- a/k8s/base/api/deployment-canary.yaml
+++ b/k8s/base/api/deployment-canary.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: api
-          image: stellar-oracle-api:canary
+          image: oracle-api:placeholder
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/k8s/base/api/deployment-stable.yaml
+++ b/k8s/base/api/deployment-stable.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: api
-          image: stellar-oracle-api:stable
+          image: oracle-api:placeholder
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/k8s/base/configmap.yaml
+++ b/k8s/base/configmap.yaml
@@ -13,6 +13,6 @@ data:
   RATE_LIMIT_MAX: "100"
   CACHE_TTL_MS: "15000"
   USE_TIMESCALEDB: "true"
-  AGGREGATOR_URL: http://aggregator.stellar-oracle-staging.svc.cluster.local:4000
-  DATABASE_URL: postgresql://oracle:oracle@timescaledb.stellar-oracle-staging.svc.cluster.local:5432/stellar_oracle
+  AGGREGATOR_URL: http://aggregator.svc.cluster.local:4000
+  DATABASE_URL: postgresql://oracle:oracle@timescaledb.svc.cluster.local:5432/stellar_oracle
   TRACING_ENABLED: "false"

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,10 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: stellar-oracle
-
 resources:
-  - namespace.yaml
   - configmap.yaml
   - aggregator/deployment.yaml
   - aggregator/service.yaml

--- a/k8s/overlays/dev/configmap-patch.yaml
+++ b/k8s/overlays/dev/configmap-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stellar-oracle-config
+data:
+  LOG_LEVEL: debug
+  AGGREGATOR_URL: http://aggregator.stellar-oracle-dev.svc.cluster.local:4000
+  DATABASE_URL: postgresql://oracle:oracle@timescaledb.stellar-oracle-dev.svc.cluster.local:5432/stellar_oracle

--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: stellar-oracle-staging
+namespace: stellar-oracle-dev
 
 resources:
   - namespace.yaml
@@ -15,18 +15,18 @@ patches:
     patch: |-
       - op: replace
         path: /spec/replicas
-        value: 2
+        value: 1
   - target:
       kind: Deployment
       name: api-canary
     patch: |-
       - op: replace
         path: /spec/replicas
-        value: 1
+        value: 0
   - target:
       kind: Deployment
       name: aggregator
     patch: |-
       - op: replace
         path: /spec/replicas
-        value: 2
+        value: 1

--- a/k8s/overlays/dev/namespace.yaml
+++ b/k8s/overlays/dev/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: stellar-oracle-dev
+  labels:
+    app.kubernetes.io/part-of: stellar-oracle
+    istio-injection: enabled

--- a/k8s/overlays/prod/configmap-patch.yaml
+++ b/k8s/overlays/prod/configmap-patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stellar-oracle-config
+data:
+  LOG_LEVEL: warn
+  AGGREGATOR_URL: http://aggregator.stellar-oracle-prod.svc.cluster.local:4000
+  DATABASE_URL: postgresql://oracle:oracle@timescaledb.stellar-oracle-prod.svc.cluster.local:5432/stellar_oracle
+  CACHE_TTL_MS: "10000"
+  RATE_LIMIT_MAX: "200"

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: stellar-oracle-staging
+namespace: stellar-oracle-prod
 
 resources:
   - namespace.yaml
@@ -15,7 +15,7 @@ patches:
     patch: |-
       - op: replace
         path: /spec/replicas
-        value: 2
+        value: 3
   - target:
       kind: Deployment
       name: api-canary
@@ -29,4 +29,4 @@ patches:
     patch: |-
       - op: replace
         path: /spec/replicas
-        value: 2
+        value: 3

--- a/k8s/overlays/prod/namespace.yaml
+++ b/k8s/overlays/prod/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: stellar-oracle-prod
+  labels:
+    app.kubernetes.io/part-of: stellar-oracle
+    istio-injection: enabled

--- a/k8s/overlays/staging/configmap-patch.yaml
+++ b/k8s/overlays/staging/configmap-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stellar-oracle-config
+data:
+  LOG_LEVEL: info
+  AGGREGATOR_URL: http://aggregator.stellar-oracle-staging.svc.cluster.local:4000
+  DATABASE_URL: postgresql://oracle:oracle@timescaledb.stellar-oracle-staging.svc.cluster.local:5432/stellar_oracle

--- a/k8s/overlays/staging/namespace.yaml
+++ b/k8s/overlays/staging/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: stellar-oracle-staging
+  labels:
+    app.kubernetes.io/part-of: stellar-oracle
+    istio-injection: enabled

--- a/scripts/deploy-k8s.sh
+++ b/scripts/deploy-k8s.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV="${1:?Usage: $0 <dev|staging|prod> <api-image> <aggregator-image>}"
+API_IMAGE="${2:?}"
+AGGREGATOR_IMAGE="${3:?}"
+
+OVERLAY="k8s/overlays/${ENV}"
+
+if [ ! -d "$OVERLAY" ]; then
+  echo "ERROR: overlay directory not found: $OVERLAY"
+  exit 1
+fi
+
+cd "$OVERLAY"
+
+kustomize edit set image oracle-api="${API_IMAGE}" oracle-aggregator="${AGGREGATOR_IMAGE}"
+
+echo "---"
+echo "Deploying to ${ENV} with:"
+echo "  API image:        ${API_IMAGE}"
+echo "  Aggregator image: ${AGGREGATOR_IMAGE}"
+echo "---"
+
+kustomize build . | kubectl apply --server-side --field-manager=kustomize -f -
+
+echo "Deployment to ${ENV} complete."


### PR DESCRIPTION
## Summary

Closes #103. Adds a full CI/CD deployment pipeline with environment promotion (dev → staging → prod), GitHub Environment approval gates for production, and one-click rollback.

## Changes

### New workflows

| Workflow | Trigger | Purpose |
|---|---|---|
| `.github/workflows/deploy.yml` | Push to `develop`/`main`, `workflow_dispatch` | Builds Docker images, deploys to dev/staging/prod |
| `.github/workflows/rollback.yml` | `workflow_dispatch` | One-click rollback to a previous commit SHA |

### New k8s environment overlays

- **`k8s/overlays/dev/`** — 1 replica, debug logging, `stellar-oracle-dev` namespace
- **`k8s/overlays/staging/`** — 2 replicas, info logging, `stellar-oracle-staging` namespace (updated)
- **`k8s/overlays/prod/`** — 3 replicas, warn logging, `stellar-oracle-prod` namespace

### Modified base manifests

- Image references replaced with placeholders (`oracle-api:placeholder`, `oracle-aggregator:placeholder`) — dynamically replaced by CI via `kustomize edit set image`
- Removed static namespace from base kustomization; each overlay provides its own `namespace.yaml`
- ConfigMap now uses generic service URLs; each overlay patches environment-specific URLs

### Helper script

`scripts/deploy-k8s.sh` — sets kustomize image overrides and runs `kubectl apply --server-side`

## Deployment flow

```
push to develop  ──► build images ──► deploy to dev (auto, env: dev)
push to main     ──► build images ──► deploy to staging (auto, env: staging)
workflow_dispatch ──► build images ──► deploy to staging or prod
                                        prod requires approval (env: production)
```

## How to use

### Deploy
1. Push to `develop` → auto-deploy to dev
2. Push to `main` → auto-deploy to staging
3. For production: go to Actions → Deploy → `Run workflow` → select `production`
4. An approver must approve the deployment in GitHub Environments

### Rollback
1. Go to Actions → Rollback → `Run workflow`
2. Select the environment and optionally specify a commit SHA (defaults to previous commit)
3. For production, an approver must approve

## Setup required

After merge, a repo admin must:

1. **Create GitHub Environments** in Settings → Environments:
   - `dev` (no protection)
   - `staging` (no protection)
   - `production` (add required reviewers)
2. **Add the following secrets** to each environment or repo:
   - `KUBECONFIG_DEV`, `KUBECONFIG_STAGING`, `KUBECONFIG_PROD` — base64-encoded kubeconfigs

## Verification

- ✅ All kustomize overlays build successfully (`kubectl kustomize` for dev/staging/prod passed)
- ✅ YAML syntax validated via Python
- ✅ CI workflows unchanged (existing `ci.yml`, `k8s-validation.yml` unaffected)