### PR TITLE
feat(infra): Terraform IaC, blue-green deployment, auto-scaling, and container security scanning

### DIFF
--- a/.github/workflows/blue-green-deploy.yml
+++ b/.github/workflows/blue-green-deploy.yml
@@ -1,0 +1,122 @@
+name: Blue-Green Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Docker image tag to deploy"
+        required: true
+      environment:
+        description: "Target environment"
+        required: true
+        default: "prod"
+        type: choice
+        options: [prod, staging]
+  push:
+    branches: [main]
+    paths:
+      - "api/**"
+      - "services/**"
+      - "Dockerfile"
+      - "api/Dockerfile"
+
+concurrency:
+  group: blue-green-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/stellar-oracle-api
+
+jobs:
+  build-and-push:
+    name: Build & Push Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image_tag: ${{ steps.meta.outputs.version }}
+      image_digest: ${{ steps.push.outputs.digest }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=sha-
+            type=ref,event=branch
+            type=raw,value=${{ github.event.inputs.image_tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        id: push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./api/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Blue-Green Deploy
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment || 'prod' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v3
+        with:
+          version: "v1.29.0"
+
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Determine image tag
+        id: image
+        run: |
+          TAG="${{ github.event.inputs.image_tag || needs.build-and-push.outputs.image_tag }}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Run blue-green deploy
+        env:
+          NAMESPACE: stellar-oracle
+          IMAGE_TAG: ${{ steps.image.outputs.tag }}
+        run: |
+          chmod +x scripts/deploy-blue-green.sh
+          ./scripts/deploy-blue-green.sh "$IMAGE_TAG"
+
+      - name: Verify deployment
+        run: |
+          kubectl rollout status deployment -l app=stellar-oracle-api \
+            -n stellar-oracle --timeout=120s
+
+      - name: Post deployment summary
+        if: always()
+        run: |
+          echo "## Deployment Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Key | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-----|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Image Tag | ${{ steps.image.outputs.tag }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Environment | ${{ github.event.inputs.environment || 'prod' }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Triggered by | ${{ github.actor }} |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,161 @@
+name: Container Security Scan
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main]
+  schedule:
+    # Re-scan the latest image nightly to catch newly-published CVEs
+    - cron: "0 3 * * *"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/stellar-oracle-api
+
+jobs:
+  build-image:
+    name: Build Image for Scanning
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image_ref: ${{ steps.build.outputs.image_ref }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image (load into daemon for scanning)
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./api/Dockerfile
+          push: false
+          load: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:scan-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Export image tar for upload
+        run: |
+          docker save "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:scan-${{ github.sha }}" \
+            -o /tmp/image.tar
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-image
+          path: /tmp/image.tar
+          retention-days: 1
+
+  trivy-scan:
+    name: Trivy Vulnerability Scan
+    needs: build-image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: docker-image
+          path: /tmp
+
+      - name: Load Docker image
+        run: docker load -i /tmp/image.tar
+
+      - name: Run Trivy — SARIF (for GitHub Security tab)
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:scan-${{ github.sha }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH,MEDIUM
+          ignore-unfixed: true
+          exit-code: "0"   # don't fail here; fail on the table scan below
+
+      - name: Upload SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-results.sarif
+
+      - name: Run Trivy — table output (human-readable)
+        id: trivy_table
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:scan-${{ github.sha }}
+          format: table
+          output: trivy-table.txt
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: "0"   # capture output; gate below
+
+      - name: Run Trivy — CRITICAL gate (fail the job)
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:scan-${{ github.sha }}
+          format: table
+          severity: CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"   # fail on any CRITICAL unfixed CVE
+
+      - name: Generate PR comment body
+        if: github.event_name == 'pull_request'
+        id: comment_body
+        run: |
+          REPORT=$(cat trivy-table.txt)
+          {
+            echo "body<<EOF"
+            echo "## Container Security Scan Results"
+            echo ""
+            echo "**Image:** \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:scan-${{ github.sha }}\`"
+            echo "**Scan date:** $(date -u '+%Y-%m-%d %H:%M UTC')"
+            echo ""
+            if grep -q "Total: 0" trivy-table.txt 2>/dev/null || [ -z "$REPORT" ]; then
+              echo "No CRITICAL or HIGH vulnerabilities found."
+            else
+              echo "<details><summary>CRITICAL / HIGH findings</summary>"
+              echo ""
+              echo '```'
+              echo "$REPORT"
+              echo '```'
+              echo ""
+              echo "</details>"
+            fi
+            echo ""
+            echo "_Full report available in the [Security tab](../security/code-scanning)._"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post PR comment
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: trivy-scan
+          message: ${{ steps.comment_body.outputs.body }}
+
+      - name: Upload full report as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-report
+          path: |
+            trivy-results.sarif
+            trivy-table.txt
+          retention-days: 30

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -1,0 +1,90 @@
+# Auto-Scaling Configuration
+
+This document describes the auto-scaling strategy for the Stellar Unified Price Oracle API backend across both Kubernetes (HPA) and AWS ECS (Application Auto Scaling).
+
+---
+
+## Kubernetes — HorizontalPodAutoscaler
+
+Two HPA resources are provided in `k8s/`:
+
+### Standard HPA (`k8s/hpa.yaml`)
+
+| Parameter | Value |
+|-----------|-------|
+| Min replicas | 2 |
+| Max replicas | 10 |
+| CPU scale-out threshold | 70% average utilization |
+| Memory scale-out threshold | 80% average utilization |
+| Scale-out window | 60 s stabilisation, max 2 pods or 100% per 60 s |
+| Scale-in window | 300 s stabilisation, max 1 pod per 120 s |
+
+The conservative scale-in policy prevents flapping during transient traffic spikes. The faster scale-out (up to doubling per minute) ensures the API absorbs sudden load without latency degradation.
+
+### Custom-Metrics HPA (`k8s/custom-metrics-hpa.yaml`)
+
+| Parameter | Value |
+|-----------|-------|
+| Primary metric | `http_requests_per_second` (Pods metric via Prometheus Adapter) |
+| Target RPS per pod | 500 |
+| Secondary metric | CPU utilization ≤ 70% (safety backstop) |
+| Min replicas | 2 |
+| Max replicas | 10 |
+| Scale-out window | 30 s stabilisation, max 3 pods per 60 s |
+| Scale-in window | 300 s stabilisation, max 1 pod per 120 s |
+
+#### Prerequisites for Custom Metrics
+
+1. **Prometheus** must be scraping the API pods on port 3001 (metrics endpoint).
+2. **prometheus-adapter** must be installed in the `monitoring` namespace and configured to expose `http_requests_per_second` through the Kubernetes custom metrics API.
+3. Verify metric availability: `kubectl get --raw /apis/custom.metrics.k8s.io/v1beta1`
+
+---
+
+## AWS ECS — Application Auto Scaling
+
+Defined in `infrastructure/terraform/modules/api/main.tf`:
+
+| Policy | Metric | Threshold | Cooldown in | Cooldown out |
+|--------|--------|-----------|-------------|--------------|
+| CPU tracking | `ECSServiceAverageCPUUtilization` | 70% | 300 s | 60 s |
+| Memory tracking | `ECSServiceAverageMemoryUtilization` | 80% | 300 s | 60 s |
+
+Capacity bounds are controlled by Terraform variables `api_min_capacity` (default 2) and `api_max_capacity` (default 10).
+
+---
+
+## Choosing Thresholds
+
+| Concern | Guidance |
+|---------|----------|
+| CPU-bound workload | Lower CPU threshold (60–70%) to give headroom before saturation |
+| Memory-bound workload | Lower memory threshold (70–75%) if the process approaches OOM before CPU redlines |
+| RPS-based | Benchmark each pod's sustainable RPS under P95 latency; set target 20% below that value |
+| Startup time | Set `scaleUp.stabilizationWindowSeconds` ≤ your pod cold-start time; don't let the controller add pods faster than they can become ready |
+
+---
+
+## Monitoring Scale Events
+
+```bash
+# Watch HPA status live
+kubectl get hpa -n stellar-oracle -w
+
+# View scale events
+kubectl describe hpa stellar-oracle-api-hpa -n stellar-oracle
+
+# ECS scale activity (AWS CLI)
+aws application-autoscaling describe-scaling-activities \
+  --service-namespace ecs \
+  --resource-id "service/stellar-oracle-cluster/stellar-oracle-api"
+```
+
+---
+
+## Tuning Checklist
+
+- [ ] Confirm pod resource requests are set (HPA requires them for CPU/memory metrics)
+- [ ] Verify Prometheus scraping port 3001 on each API pod
+- [ ] Run load test (`load-tests/`) and observe HPA behaviour before go-live
+- [ ] Set alert on `kube_horizontalpodautoscaler_status_current_replicas == kube_horizontalpodautoscaler_spec_max_replicas` to know when you've hit the ceiling

--- a/infrastructure/terraform/README.md
+++ b/infrastructure/terraform/README.md
@@ -1,0 +1,94 @@
+# Stellar Oracle — Terraform Infrastructure
+
+This directory contains Terraform configuration for deploying the Stellar Unified Price Oracle API Backend on AWS using ECS Fargate and RDS PostgreSQL.
+
+## Architecture
+
+```
+Internet
+  │
+  ▼
+ALB (public subnets)
+  │
+  ▼
+ECS Fargate — API Tasks (private subnets)
+  │
+  ▼
+RDS PostgreSQL (private subnets)
+```
+
+## Modules
+
+| Module | Description |
+|--------|-------------|
+| `modules/api` | ECS Fargate service, ALB, IAM roles, auto-scaling policies |
+| `modules/database` | RDS PostgreSQL instance, subnet group, security group |
+
+## Prerequisites
+
+- Terraform >= 1.5.0
+- AWS CLI configured with appropriate credentials
+- An S3 bucket + DynamoDB table for remote state (recommended)
+- An ACM certificate ARN if you want HTTPS
+
+## Quick Start
+
+```bash
+# 1. Initialise (configure backend first)
+terraform init \
+  -backend-config="bucket=my-tf-state" \
+  -backend-config="key=stellar-oracle/terraform.tfstate" \
+  -backend-config="region=us-east-1"
+
+# 2. Create a tfvars file
+cat > prod.tfvars <<EOF
+aws_region  = "us-east-1"
+environment = "prod"
+api_image   = "123456789.dkr.ecr.us-east-1.amazonaws.com/stellar-oracle-api:latest"
+db_password = "CHANGE_ME_USE_SECRETS_MANAGER"
+EOF
+
+# 3. Plan
+terraform plan -var-file=prod.tfvars
+
+# 4. Apply
+terraform apply -var-file=prod.tfvars
+```
+
+## Key Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `aws_region` | AWS region | `us-east-1` |
+| `environment` | Environment name | `prod` |
+| `api_image` | Docker image URI | _(required)_ |
+| `api_min_capacity` | Min ECS tasks | `2` |
+| `api_max_capacity` | Max ECS tasks | `10` |
+| `db_instance_class` | RDS instance class | `db.t3.medium` |
+| `db_password` | DB master password | _(required, sensitive)_ |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `api_url` | Public API URL (HTTP or HTTPS) |
+| `api_load_balancer_dns` | ALB DNS name |
+| `db_endpoint` | RDS endpoint (sensitive) |
+| `ecs_cluster_name` | ECS cluster name |
+| `ecs_service_name` | ECS service name |
+
+## Auto Scaling
+
+Two target-tracking policies are attached to the ECS service:
+- **CPU**: scales out when average CPU > 70%, scales in after 5 min cooldown
+- **Memory**: scales out when average memory > 80%, scales in after 5 min cooldown
+
+Capacity bounds: min 2 / max 10 tasks (configurable via `api_min_capacity` / `api_max_capacity`).
+
+## Destroying
+
+```bash
+terraform destroy -var-file=prod.tfvars
+```
+
+Production environments have `deletion_protection = true` on the RDS instance. Disable it first if you need a full teardown.

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -1,0 +1,176 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+    # Configure via -backend-config flags or a backend.hcl file
+    # bucket         = "your-terraform-state-bucket"
+    # key            = "stellar-oracle/terraform.tfstate"
+    # region         = "us-east-1"
+    # dynamodb_table = "terraform-state-lock"
+    # encrypt        = true
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = var.tags
+  }
+}
+
+# ── Networking ────────────────────────────────────────────────────────────────
+
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = { Name = "${var.project_name}-vpc" }
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_subnet" "private" {
+  count             = length(var.private_subnet_cidrs)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.private_subnet_cidrs[count.index]
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+
+  tags = { Name = "${var.project_name}-private-${count.index + 1}" }
+}
+
+resource "aws_subnet" "public" {
+  count                   = length(var.public_subnet_cidrs)
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_cidrs[count.index]
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  map_public_ip_on_launch = true
+
+  tags = { Name = "${var.project_name}-public-${count.index + 1}" }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+  tags   = { Name = "${var.project_name}-igw" }
+}
+
+resource "aws_eip" "nat" {
+  count  = length(var.public_subnet_cidrs)
+  domain = "vpc"
+}
+
+resource "aws_nat_gateway" "main" {
+  count         = length(var.public_subnet_cidrs)
+  allocation_id = aws_eip.nat[count.index].id
+  subnet_id     = aws_subnet.public[count.index].id
+
+  tags = { Name = "${var.project_name}-nat-${count.index + 1}" }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = { Name = "${var.project_name}-public-rt" }
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(aws_subnet.public)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  count  = length(aws_subnet.private)
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.main[count.index].id
+  }
+
+  tags = { Name = "${var.project_name}-private-rt-${count.index + 1}" }
+}
+
+resource "aws_route_table_association" "private" {
+  count          = length(aws_subnet.private)
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[count.index].id
+}
+
+# ── ECS Cluster ───────────────────────────────────────────────────────────────
+
+resource "aws_ecs_cluster" "main" {
+  name = "${var.project_name}-cluster"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+}
+
+resource "aws_ecs_cluster_capacity_providers" "main" {
+  cluster_name       = aws_ecs_cluster.main.name
+  capacity_providers = ["FARGATE", "FARGATE_SPOT"]
+
+  default_capacity_provider_strategy {
+    base              = 1
+    weight            = 100
+    capacity_provider = "FARGATE"
+  }
+}
+
+# ── API Module ────────────────────────────────────────────────────────────────
+
+module "api" {
+  source = "./modules/api"
+
+  project_name      = var.project_name
+  environment       = var.environment
+  cluster_id        = aws_ecs_cluster.main.id
+  cluster_name      = aws_ecs_cluster.main.name
+  private_subnet_ids = aws_subnet.private[*].id
+  public_subnet_ids  = aws_subnet.public[*].id
+  vpc_id            = aws_vpc.main.id
+  api_image         = var.api_image
+  cpu               = var.api_cpu
+  memory            = var.api_memory
+  desired_count     = var.api_desired_count
+  min_capacity      = var.api_min_capacity
+  max_capacity      = var.api_max_capacity
+  certificate_arn   = var.certificate_arn
+  db_host           = module.database.db_endpoint
+  db_name           = var.db_name
+  db_username       = var.db_username
+  db_password       = var.db_password
+}
+
+# ── Database Module ───────────────────────────────────────────────────────────
+
+module "database" {
+  source = "./modules/database"
+
+  project_name             = var.project_name
+  environment              = var.environment
+  vpc_id                   = aws_vpc.main.id
+  private_subnet_ids       = aws_subnet.private[*].id
+  api_security_group_id    = module.api.security_group_id
+  db_name                  = var.db_name
+  db_username              = var.db_username
+  db_password              = var.db_password
+  instance_class           = var.db_instance_class
+  allocated_storage        = var.db_allocated_storage
+  max_allocated_storage    = var.db_max_allocated_storage
+}

--- a/infrastructure/terraform/modules/api/main.tf
+++ b/infrastructure/terraform/modules/api/main.tf
@@ -1,0 +1,326 @@
+variable "project_name"       { type = string }
+variable "environment"        { type = string }
+variable "cluster_id"         { type = string }
+variable "cluster_name"       { type = string }
+variable "vpc_id"             { type = string }
+variable "private_subnet_ids" { type = list(string) }
+variable "public_subnet_ids"  { type = list(string) }
+variable "api_image"          { type = string }
+variable "cpu"                { type = number }
+variable "memory"             { type = number }
+variable "desired_count"      { type = number }
+variable "min_capacity"       { type = number }
+variable "max_capacity"       { type = number }
+variable "certificate_arn"    { type = string }
+variable "db_host"            { type = string }
+variable "db_name"            { type = string }
+variable "db_username"        { type = string; sensitive = true }
+variable "db_password"        { type = string; sensitive = true }
+
+# ── IAM ───────────────────────────────────────────────────────────────────────
+
+resource "aws_iam_role" "ecs_task_execution" {
+  name = "${var.project_name}-ecs-task-execution"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution" {
+  role       = aws_iam_role.ecs_task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role" "ecs_task" {
+  name = "${var.project_name}-ecs-task"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+    }]
+  })
+}
+
+# ── Security Groups ───────────────────────────────────────────────────────────
+
+resource "aws_security_group" "alb" {
+  name        = "${var.project_name}-alb-sg"
+  description = "Allow HTTP/HTTPS inbound to ALB"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "api" {
+  name        = "${var.project_name}-api-sg"
+  description = "Allow traffic from ALB to API tasks"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port       = 3000
+    to_port         = 3001
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# ── CloudWatch Log Group ──────────────────────────────────────────────────────
+
+resource "aws_cloudwatch_log_group" "api" {
+  name              = "/ecs/${var.project_name}/api"
+  retention_in_days = 30
+}
+
+# ── ECS Task Definition ───────────────────────────────────────────────────────
+
+resource "aws_ecs_task_definition" "api" {
+  family                   = "${var.project_name}-api"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.cpu
+  memory                   = var.memory
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.ecs_task.arn
+
+  container_definitions = jsonencode([{
+    name      = "api"
+    image     = var.api_image
+    essential = true
+
+    portMappings = [
+      { containerPort = 3000, protocol = "tcp" },
+      { containerPort = 3001, protocol = "tcp" }
+    ]
+
+    environment = [
+      { name = "NODE_ENV",   value = var.environment },
+      { name = "DB_HOST",    value = var.db_host },
+      { name = "DB_NAME",    value = var.db_name },
+      { name = "DB_USER",    value = var.db_username },
+      { name = "DB_PASSWORD", value = var.db_password },
+      { name = "PORT",       value = "3000" }
+    ]
+
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        "awslogs-group"         = aws_cloudwatch_log_group.api.name
+        "awslogs-region"        = data.aws_region.current.name
+        "awslogs-stream-prefix" = "api"
+      }
+    }
+
+    healthCheck = {
+      command     = ["CMD-SHELL", "wget -qO- http://localhost:3000/health || exit 1"]
+      interval    = 30
+      timeout     = 5
+      retries     = 3
+      startPeriod = 60
+    }
+  }])
+}
+
+data "aws_region" "current" {}
+
+# ── Application Load Balancer ─────────────────────────────────────────────────
+
+resource "aws_lb" "api" {
+  name               = "${var.project_name}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = var.public_subnet_ids
+}
+
+resource "aws_lb_target_group" "api" {
+  name        = "${var.project_name}-api-tg"
+  port        = 3000
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    path                = "/health"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    interval            = 30
+    timeout             = 5
+  }
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.api.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = var.certificate_arn != "" ? "redirect" : "forward"
+
+    dynamic "redirect" {
+      for_each = var.certificate_arn != "" ? [1] : []
+      content {
+        port        = "443"
+        protocol    = "HTTPS"
+        status_code = "HTTP_301"
+      }
+    }
+
+    dynamic "forward" {
+      for_each = var.certificate_arn == "" ? [1] : []
+      content {
+        target_group {
+          arn = aws_lb_target_group.api.arn
+        }
+      }
+    }
+  }
+}
+
+resource "aws_lb_listener" "https" {
+  count             = var.certificate_arn != "" ? 1 : 0
+  load_balancer_arn = aws_lb.api.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = var.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.api.arn
+  }
+}
+
+# ── ECS Service ───────────────────────────────────────────────────────────────
+
+resource "aws_ecs_service" "api" {
+  name            = "${var.project_name}-api"
+  cluster         = var.cluster_id
+  task_definition = aws_ecs_task_definition.api.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets         = var.private_subnet_ids
+    security_groups = [aws_security_group.api.id]
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.api.arn
+    container_name   = "api"
+    container_port   = 3000
+  }
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+}
+
+# ── Auto Scaling ──────────────────────────────────────────────────────────────
+
+resource "aws_appautoscaling_target" "api" {
+  max_capacity       = var.max_capacity
+  min_capacity       = var.min_capacity
+  resource_id        = "service/${var.cluster_name}/${aws_ecs_service.api.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "cpu" {
+  name               = "${var.project_name}-cpu-scaling"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.api.resource_id
+  scalable_dimension = aws_appautoscaling_target.api.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.api.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+    target_value       = 70.0
+    scale_in_cooldown  = 300
+    scale_out_cooldown = 60
+  }
+}
+
+resource "aws_appautoscaling_policy" "memory" {
+  name               = "${var.project_name}-memory-scaling"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.api.resource_id
+  scalable_dimension = aws_appautoscaling_target.api.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.api.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageMemoryUtilization"
+    }
+    target_value       = 80.0
+    scale_in_cooldown  = 300
+    scale_out_cooldown = 60
+  }
+}
+
+# ── Outputs ───────────────────────────────────────────────────────────────────
+
+output "api_url" {
+  value = var.certificate_arn != "" ? "https://${aws_lb.api.dns_name}" : "http://${aws_lb.api.dns_name}"
+}
+
+output "load_balancer_dns" {
+  value = aws_lb.api.dns_name
+}
+
+output "service_name" {
+  value = aws_ecs_service.api.name
+}
+
+output "security_group_id" {
+  value = aws_security_group.api.id
+}
+
+output "target_group_arn" {
+  value = aws_lb_target_group.api.arn
+}
+
+output "load_balancer_arn" {
+  value = aws_lb.api.arn
+}

--- a/infrastructure/terraform/modules/database/main.tf
+++ b/infrastructure/terraform/modules/database/main.tf
@@ -1,0 +1,74 @@
+variable "project_name"          { type = string }
+variable "environment"           { type = string }
+variable "vpc_id"                { type = string }
+variable "private_subnet_ids"    { type = list(string) }
+variable "api_security_group_id" { type = string }
+variable "db_name"               { type = string }
+variable "db_username"           { type = string; sensitive = true }
+variable "db_password"           { type = string; sensitive = true }
+variable "instance_class"        { type = string }
+variable "allocated_storage"     { type = number }
+variable "max_allocated_storage" { type = number }
+
+resource "aws_security_group" "db" {
+  name        = "${var.project_name}-db-sg"
+  description = "Allow PostgreSQL from API tasks only"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [var.api_security_group_id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_db_subnet_group" "main" {
+  name       = "${var.project_name}-db-subnet-group"
+  subnet_ids = var.private_subnet_ids
+}
+
+resource "aws_db_instance" "main" {
+  identifier             = "${var.project_name}-postgres"
+  engine                 = "postgres"
+  engine_version         = "15.4"
+  instance_class         = var.instance_class
+  allocated_storage      = var.allocated_storage
+  max_allocated_storage  = var.max_allocated_storage
+  storage_type           = "gp3"
+  storage_encrypted      = true
+  db_name                = var.db_name
+  username               = var.db_username
+  password               = var.db_password
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+  vpc_security_group_ids = [aws_security_group.db.id]
+  multi_az               = var.environment == "prod" ? true : false
+  publicly_accessible    = false
+  skip_final_snapshot    = var.environment != "prod"
+  deletion_protection    = var.environment == "prod"
+
+  backup_retention_period = 7
+  backup_window           = "03:00-04:00"
+  maintenance_window      = "sun:04:00-sun:05:00"
+
+  performance_insights_enabled = true
+  monitoring_interval          = 60
+
+  tags = { Name = "${var.project_name}-postgres" }
+}
+
+output "db_endpoint" {
+  value     = aws_db_instance.main.endpoint
+  sensitive = true
+}
+
+output "db_security_group_id" {
+  value = aws_security_group.db.id
+}

--- a/infrastructure/terraform/outputs.tf
+++ b/infrastructure/terraform/outputs.tf
@@ -1,0 +1,40 @@
+output "api_url" {
+  description = "Public URL of the API load balancer"
+  value       = module.api.api_url
+}
+
+output "api_load_balancer_dns" {
+  description = "DNS name of the application load balancer"
+  value       = module.api.load_balancer_dns
+}
+
+output "db_endpoint" {
+  description = "RDS PostgreSQL endpoint (host:port)"
+  value       = module.database.db_endpoint
+  sensitive   = true
+}
+
+output "db_name" {
+  description = "Database name"
+  value       = var.db_name
+}
+
+output "ecs_cluster_name" {
+  description = "ECS cluster name"
+  value       = aws_ecs_cluster.main.name
+}
+
+output "ecs_service_name" {
+  description = "ECS service name for the API"
+  value       = module.api.service_name
+}
+
+output "vpc_id" {
+  description = "VPC ID"
+  value       = aws_vpc.main.id
+}
+
+output "private_subnet_ids" {
+  description = "Private subnet IDs"
+  value       = aws_subnet.private[*].id
+}

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -1,0 +1,122 @@
+variable "aws_region" {
+  description = "AWS region to deploy resources"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "environment" {
+  description = "Deployment environment (dev, staging, prod)"
+  type        = string
+  default     = "prod"
+}
+
+variable "project_name" {
+  description = "Project name prefix for all resources"
+  type        = string
+  default     = "stellar-oracle"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "private_subnet_cidrs" {
+  description = "CIDR blocks for private subnets"
+  type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.2.0/24"]
+}
+
+variable "public_subnet_cidrs" {
+  description = "CIDR blocks for public subnets"
+  type        = list(string)
+  default     = ["10.0.101.0/24", "10.0.102.0/24"]
+}
+
+variable "api_image" {
+  description = "Docker image URI for the API service"
+  type        = string
+}
+
+variable "api_cpu" {
+  description = "CPU units for the API ECS task (1 vCPU = 1024)"
+  type        = number
+  default     = 512
+}
+
+variable "api_memory" {
+  description = "Memory (MiB) for the API ECS task"
+  type        = number
+  default     = 1024
+}
+
+variable "api_desired_count" {
+  description = "Desired number of API task instances"
+  type        = number
+  default     = 2
+}
+
+variable "api_min_capacity" {
+  description = "Minimum number of API task instances for auto-scaling"
+  type        = number
+  default     = 2
+}
+
+variable "api_max_capacity" {
+  description = "Maximum number of API task instances for auto-scaling"
+  type        = number
+  default     = 10
+}
+
+variable "db_instance_class" {
+  description = "RDS instance class"
+  type        = string
+  default     = "db.t3.medium"
+}
+
+variable "db_name" {
+  description = "PostgreSQL database name"
+  type        = string
+  default     = "oracle_db"
+}
+
+variable "db_username" {
+  description = "PostgreSQL master username"
+  type        = string
+  default     = "oracle_admin"
+  sensitive   = true
+}
+
+variable "db_password" {
+  description = "PostgreSQL master password"
+  type        = string
+  sensitive   = true
+}
+
+variable "db_allocated_storage" {
+  description = "Allocated storage in GiB for RDS"
+  type        = number
+  default     = 50
+}
+
+variable "db_max_allocated_storage" {
+  description = "Maximum storage autoscaling limit in GiB"
+  type        = number
+  default     = 200
+}
+
+variable "certificate_arn" {
+  description = "ACM certificate ARN for HTTPS on the load balancer"
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  description = "Common tags applied to all resources"
+  type        = map(string)
+  default = {
+    Project   = "stellar-oracle"
+    ManagedBy = "terraform"
+  }
+}

--- a/k8s/blue-green/blue-deployment.yaml
+++ b/k8s/blue-green/blue-deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stellar-oracle-api-blue
+  namespace: stellar-oracle
+  labels:
+    app: stellar-oracle-api
+    slot: blue
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: stellar-oracle-api
+      slot: blue
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: stellar-oracle-api
+        slot: blue
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: api
+          image: ghcr.io/stellar-unified-price-oracle/stellar-oracle-api:IMAGE_TAG_PLACEHOLDER
+          ports:
+            - containerPort: 3000
+              name: http
+            - containerPort: 3001
+              name: metrics
+          env:
+            - name: NODE_ENV
+              value: production
+            - name: DEPLOYMENT_SLOT
+              value: blue
+          envFrom:
+            - secretRef:
+                name: stellar-oracle-secrets
+            - configMapRef:
+                name: stellar-oracle-config
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1024Mi"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 3
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 10"]

--- a/k8s/blue-green/green-deployment.yaml
+++ b/k8s/blue-green/green-deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stellar-oracle-api-green
+  namespace: stellar-oracle
+  labels:
+    app: stellar-oracle-api
+    slot: green
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: stellar-oracle-api
+      slot: green
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: stellar-oracle-api
+        slot: green
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: api
+          image: ghcr.io/stellar-unified-price-oracle/stellar-oracle-api:IMAGE_TAG_PLACEHOLDER
+          ports:
+            - containerPort: 3000
+              name: http
+            - containerPort: 3001
+              name: metrics
+          env:
+            - name: NODE_ENV
+              value: production
+            - name: DEPLOYMENT_SLOT
+              value: green
+          envFrom:
+            - secretRef:
+                name: stellar-oracle-secrets
+            - configMapRef:
+                name: stellar-oracle-config
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1024Mi"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 3
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 10"]

--- a/k8s/blue-green/service.yaml
+++ b/k8s/blue-green/service.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: stellar-oracle-api
+  namespace: stellar-oracle
+  labels:
+    app: stellar-oracle-api
+  annotations:
+    # Updated by deploy-blue-green.sh — do not edit manually
+    deployment/active-slot: blue
+spec:
+  type: ClusterIP
+  selector:
+    app: stellar-oracle-api
+    # deploy-blue-green.sh patches this value between "blue" and "green"
+    slot: blue
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3000
+      protocol: TCP
+    - name: metrics
+      port: 3001
+      targetPort: 3001
+      protocol: TCP

--- a/k8s/custom-metrics-hpa.yaml
+++ b/k8s/custom-metrics-hpa.yaml
@@ -1,0 +1,55 @@
+# custom-metrics-hpa.yaml — HPA driven by requests-per-second via Prometheus Adapter
+# Prerequisite: install prometheus-adapter and configure custom metric
+# "http_requests_per_second" from your Prometheus scrape target.
+#
+# Install adapter:
+#   helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+#   helm install prometheus-adapter prometheus-community/prometheus-adapter \
+#     --namespace monitoring --create-namespace \
+#     -f k8s/prometheus-adapter-values.yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: stellar-oracle-api-custom-hpa
+  namespace: stellar-oracle
+  labels:
+    app: stellar-oracle-api
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: stellar-oracle-api-blue
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    # Scale based on incoming HTTP requests per second per pod
+    - type: Pods
+      pods:
+        metric:
+          name: http_requests_per_second
+        target:
+          type: AverageValue
+          # Scale out when > 500 RPS per pod
+          averageValue: "500"
+    # Also respect CPU as a safety backstop
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 30
+      policies:
+        - type: Pods
+          value: 3
+          periodSeconds: 60
+      selectPolicy: Max
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 120
+      selectPolicy: Min

--- a/k8s/hpa.yaml
+++ b/k8s/hpa.yaml
@@ -1,0 +1,46 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: stellar-oracle-api-hpa
+  namespace: stellar-oracle
+  labels:
+    app: stellar-oracle-api
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    # Targets whichever slot is currently active; update selector if using blue-green
+    name: stellar-oracle-api-blue
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+        - type: Percent
+          value: 100
+          periodSeconds: 60
+      selectPolicy: Max
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 120
+      selectPolicy: Min

--- a/scripts/deploy-blue-green.sh
+++ b/scripts/deploy-blue-green.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# deploy-blue-green.sh — Blue/green deployment for Stellar Oracle API
+#
+# Usage:
+#   ./scripts/deploy-blue-green.sh <IMAGE_TAG>
+#
+# Environment variables (with defaults):
+#   NAMESPACE          Kubernetes namespace            (default: stellar-oracle)
+#   HEALTH_URL         URL to smoke-test after cutover (default: http://localhost:3000/health)
+#   SMOKE_RETRIES      Number of health-check retries  (default: 20)
+#   SMOKE_INTERVAL     Seconds between retries         (default: 10)
+#   DRY_RUN            Set to "true" to skip kubectl apply (default: false)
+#
+# Dependencies: kubectl, jq
+set -euo pipefail
+
+# ── Args & Config ──────────────────────────────────────────────────────────────
+IMAGE_TAG="${1:?Usage: $0 <image-tag>}"
+NAMESPACE="${NAMESPACE:-stellar-oracle}"
+HEALTH_URL="${HEALTH_URL:-http://localhost:3000/health}"
+SMOKE_RETRIES="${SMOKE_RETRIES:-20}"
+SMOKE_INTERVAL="${SMOKE_INTERVAL:-10}"
+DRY_RUN="${DRY_RUN:-false}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+K8S_DIR="${SCRIPT_DIR}/../k8s/blue-green"
+
+log()  { echo "[$(date -u +%H:%M:%S)] $*"; }
+info() { log "INFO  $*"; }
+warn() { log "WARN  $*"; }
+err()  { log "ERROR $*" >&2; }
+
+kubectl_apply() {
+  if [[ "$DRY_RUN" == "true" ]]; then
+    info "[dry-run] kubectl apply $*"
+  else
+    kubectl apply "$@"
+  fi
+}
+
+# ── Determine active slot ──────────────────────────────────────────────────────
+info "Detecting active deployment slot..."
+ACTIVE_SLOT=$(kubectl get service stellar-oracle-api \
+  -n "$NAMESPACE" \
+  -o jsonpath='{.spec.selector.slot}' 2>/dev/null || echo "blue")
+
+if [[ "$ACTIVE_SLOT" == "blue" ]]; then
+  ACTIVE="blue"
+  GREEN="green"
+else
+  ACTIVE="green"
+  GREEN="blue"
+fi
+
+info "Active slot: ${ACTIVE}  →  deploying to: ${GREEN}"
+
+# ── Update green deployment ────────────────────────────────────────────────────
+GREEN_MANIFEST="${K8S_DIR}/${GREEN}-deployment.yaml"
+if [[ ! -f "$GREEN_MANIFEST" ]]; then
+  err "Manifest not found: ${GREEN_MANIFEST}"
+  exit 1
+fi
+
+info "Patching image tag to ${IMAGE_TAG} in ${GREEN} deployment..."
+TMP_MANIFEST=$(mktemp)
+sed "s|IMAGE_TAG_PLACEHOLDER|${IMAGE_TAG}|g" "$GREEN_MANIFEST" > "$TMP_MANIFEST"
+
+info "Applying ${GREEN} deployment..."
+kubectl_apply -f "$TMP_MANIFEST" -n "$NAMESPACE"
+rm -f "$TMP_MANIFEST"
+
+# ── Wait for green rollout ─────────────────────────────────────────────────────
+info "Waiting for ${GREEN} rollout to complete..."
+if [[ "$DRY_RUN" != "true" ]]; then
+  kubectl rollout status deployment/stellar-oracle-api-${GREEN} \
+    -n "$NAMESPACE" --timeout=300s
+fi
+
+# ── Smoke tests ────────────────────────────────────────────────────────────────
+info "Running smoke tests against ${GREEN} (${HEALTH_URL})..."
+
+# Port-forward to the green deployment for smoke testing
+if [[ "$DRY_RUN" != "true" ]]; then
+  kubectl port-forward -n "$NAMESPACE" \
+    "deployment/stellar-oracle-api-${GREEN}" 18080:3000 &
+  PF_PID=$!
+  sleep 3
+
+  SMOKE_OK=false
+  for i in $(seq 1 "$SMOKE_RETRIES"); do
+    if curl -sf "http://localhost:18080/health" -o /dev/null; then
+      info "Smoke test passed (attempt ${i})"
+      SMOKE_OK=true
+      break
+    fi
+    warn "Smoke test attempt ${i}/${SMOKE_RETRIES} failed — retrying in ${SMOKE_INTERVAL}s..."
+    sleep "$SMOKE_INTERVAL"
+  done
+
+  kill "$PF_PID" 2>/dev/null || true
+  wait "$PF_PID" 2>/dev/null || true
+
+  if [[ "$SMOKE_OK" != "true" ]]; then
+    err "Smoke tests failed — aborting traffic switch. ${GREEN} deployment left running for inspection."
+    exit 1
+  fi
+fi
+
+# ── Switch traffic to green ────────────────────────────────────────────────────
+info "Switching service traffic from ${ACTIVE} → ${GREEN}..."
+kubectl_apply -f "${K8S_DIR}/service.yaml" \
+  --dry-run=none 2>/dev/null || true
+
+if [[ "$DRY_RUN" != "true" ]]; then
+  kubectl patch service stellar-oracle-api \
+    -n "$NAMESPACE" \
+    --type=json \
+    -p "[{\"op\":\"replace\",\"path\":\"/spec/selector/slot\",\"value\":\"${GREEN}\"}]"
+fi
+
+info "Traffic now routing to slot: ${GREEN}"
+
+# ── Tear down old (active/blue) deployment ─────────────────────────────────────
+info "Scaling down old ${ACTIVE} deployment..."
+if [[ "$DRY_RUN" != "true" ]]; then
+  kubectl scale deployment "stellar-oracle-api-${ACTIVE}" \
+    --replicas=0 -n "$NAMESPACE" || warn "Could not scale down ${ACTIVE} (may not exist yet)"
+fi
+
+info "Blue-green deployment complete."
+info "  New active slot : ${GREEN}"
+info "  Image tag       : ${IMAGE_TAG}"
+info "  Old slot        : ${ACTIVE} (scaled to 0 — delete when satisfied)"

--- a/scripts/scan-image.sh
+++ b/scripts/scan-image.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# scan-image.sh — Local vulnerability scan helper using Trivy
+#
+# Usage:
+#   ./scripts/scan-image.sh [IMAGE_TAG]
+#
+# If IMAGE_TAG is omitted the script builds the API image from source first.
+#
+# Environment variables:
+#   DOCKERFILE      Path to Dockerfile        (default: ./api/Dockerfile)
+#   IMAGE_NAME      Image name                (default: stellar-oracle-api)
+#   SEVERITY        Comma-separated levels    (default: CRITICAL,HIGH)
+#   IGNORE_UNFIXED  Skip unfixed CVEs (true/false, default: true)
+#   OUTPUT_FORMAT   table|json|sarif          (default: table)
+#   FAIL_ON_CRITICAL Exit 1 on CRITICAL CVEs  (default: true)
+set -euo pipefail
+
+DOCKERFILE="${DOCKERFILE:-./api/Dockerfile}"
+IMAGE_NAME="${IMAGE_NAME:-stellar-oracle-api}"
+SEVERITY="${SEVERITY:-CRITICAL,HIGH}"
+IGNORE_UNFIXED="${IGNORE_UNFIXED:-true}"
+OUTPUT_FORMAT="${OUTPUT_FORMAT:-table}"
+FAIL_ON_CRITICAL="${FAIL_ON_CRITICAL:-true}"
+
+IMAGE_TAG="${1:-}"
+BUILT_LOCALLY=false
+
+log()  { echo "[$(date -u +%H:%M:%S)] $*"; }
+info() { log "INFO  $*"; }
+err()  { log "ERROR $*" >&2; }
+
+# ── Ensure Trivy is installed ──────────────────────────────────────────────────
+if ! command -v trivy &>/dev/null; then
+  info "Trivy not found — installing via script..."
+  curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
+    | sh -s -- -b "$HOME/.local/bin"
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
+TRIVY_VERSION=$(trivy --version 2>&1 | head -1)
+info "Using: ${TRIVY_VERSION}"
+
+# ── Build image if no tag supplied ─────────────────────────────────────────────
+if [[ -z "$IMAGE_TAG" ]]; then
+  IMAGE_TAG="local-scan-$(date +%Y%m%d%H%M%S)"
+  info "No image tag supplied — building from ${DOCKERFILE}..."
+
+  if [[ ! -f "$DOCKERFILE" ]]; then
+    err "Dockerfile not found: ${DOCKERFILE}"
+    exit 1
+  fi
+
+  docker build -f "$DOCKERFILE" -t "${IMAGE_NAME}:${IMAGE_TAG}" .
+  BUILT_LOCALLY=true
+  info "Built image: ${IMAGE_NAME}:${IMAGE_TAG}"
+else
+  info "Scanning image: ${IMAGE_TAG}"
+fi
+
+# Resolve full image ref
+if [[ "$IMAGE_TAG" == *":"* ]]; then
+  IMAGE_REF="$IMAGE_TAG"
+else
+  IMAGE_REF="${IMAGE_NAME}:${IMAGE_TAG}"
+fi
+
+# ── Build Trivy flags ──────────────────────────────────────────────────────────
+TRIVY_FLAGS=(
+  image
+  --severity "$SEVERITY"
+  --format   "$OUTPUT_FORMAT"
+)
+
+if [[ "$IGNORE_UNFIXED" == "true" ]]; then
+  TRIVY_FLAGS+=(--ignore-unfixed)
+fi
+
+# Write JSON/SARIF to a file; print table to stdout
+OUTPUT_FILE=""
+if [[ "$OUTPUT_FORMAT" == "json" ]]; then
+  OUTPUT_FILE="trivy-report-$(date +%Y%m%d%H%M%S).json"
+  TRIVY_FLAGS+=(--output "$OUTPUT_FILE")
+elif [[ "$OUTPUT_FORMAT" == "sarif" ]]; then
+  OUTPUT_FILE="trivy-report-$(date +%Y%m%d%H%M%S).sarif"
+  TRIVY_FLAGS+=(--output "$OUTPUT_FILE")
+fi
+
+# ── Run scan ───────────────────────────────────────────────────────────────────
+info "Running Trivy scan (severity: ${SEVERITY})..."
+SCAN_EXIT=0
+trivy "${TRIVY_FLAGS[@]}" "$IMAGE_REF" || SCAN_EXIT=$?
+
+if [[ -n "$OUTPUT_FILE" ]]; then
+  info "Report saved to: ${OUTPUT_FILE}"
+fi
+
+# ── Clean up locally-built image ───────────────────────────────────────────────
+if [[ "$BUILT_LOCALLY" == "true" ]]; then
+  docker rmi "${IMAGE_NAME}:${IMAGE_TAG}" 2>/dev/null || true
+fi
+
+# ── Gate on CRITICAL ───────────────────────────────────────────────────────────
+if [[ "$FAIL_ON_CRITICAL" == "true" && "$SCAN_EXIT" -ne 0 ]]; then
+  # Re-run with only CRITICAL to give a targeted exit code
+  CRITICAL_EXIT=0
+  trivy image --severity CRITICAL --ignore-unfixed --quiet "$IMAGE_REF" || CRITICAL_EXIT=$?
+  if [[ "$CRITICAL_EXIT" -ne 0 ]]; then
+    err "CRITICAL vulnerabilities detected — failing build."
+    exit 1
+  fi
+fi
+
+info "Scan complete. Exit code: ${SCAN_EXIT}"
+exit "$SCAN_EXIT"


### PR DESCRIPTION
Closes #98
Closes #99
Closes #100
Closes #104

---

## Oracle Backend — issues #98, #99, #100, #104

### #98 — Terraform Infrastructure-as-Code

Added `infrastructure/terraform/` with main.tf, variables.tf, outputs.tf, modules/api (ECS Fargate + ALB + auto-scaling), modules/database (RDS PostgreSQL 15.4), and README.

### #99 — Blue-Green Deployment Strategy

- scripts/deploy-blue-green.sh — slot detection, green deploy, smoke test, traffic switch, old slot scale-down
- k8s/blue-green/ — blue-deployment.yaml, green-deployment.yaml, service.yaml
- .github/workflows/blue-green-deploy.yml

### #100 — Auto-Scaling Configuration

- k8s/hpa.yaml — CPU >= 70%, memory >= 80%, min 2 / max 10 replicas
- k8s/custom-metrics-hpa.yaml — RPS-based HPA (500 RPS/pod via Prometheus Adapter) with CPU backstop
- ECS AppAutoScaling policies in modules/api
- docs/scaling.md — thresholds, tuning guide, monitoring commands

### #104 — Container Image Vulnerability Scanning

- .github/workflows/security-scan.yml — Trivy on every PR and main push, SARIF upload, sticky PR comment, fails on CRITICAL, nightly re-scan
- scripts/scan-image.sh — local Trivy helper