### PR TITLE
Fix 4 bugs: API key storage, contract history helper, compose file, history growth

### DIFF
--- a/api/src/governance/admin.ts
+++ b/api/src/governance/admin.ts
@@ -94,8 +94,7 @@ router.get('/keys/:keyHash', (req: Request, res: Response) => {
       error: { code: 'KEY_NOT_FOUND', message: 'API key not found' },
     });
   }
-  const { key: _key, ...safeInfo } = keyInfo;
-  res.json({ success: true, data: safeInfo });
+  res.json({ success: true, data: keyInfo });
 });
 
 router.post('/keys/:keyHash/rotate', (req: Request, res: Response) => {
@@ -107,7 +106,7 @@ router.post('/keys/:keyHash/rotate', (req: Request, res: Response) => {
     });
   }
 
-  const rotated = apiKeyManager.rotateKey(existing.key);
+  const rotated = apiKeyManager.rotateKey(req.params.keyHash);
   if (!rotated) {
     return res.status(500).json({
       success: false,
@@ -148,7 +147,7 @@ router.put('/keys/:keyHash/tier', (req: Request, res: Response) => {
     });
   }
 
-  apiKeyManager.updateTier(existing.key, tier as KeyTier);
+  apiKeyManager.updateTier(req.params.keyHash, tier as KeyTier);
   res.json({
     success: true,
     data: { keyHash: req.params.keyHash, tier, rateLimitPerMin: TIER_RATE_LIMITS[tier as KeyTier] },
@@ -173,7 +172,7 @@ router.put('/keys/:keyHash/rate-limit', (req: Request, res: Response) => {
     });
   }
 
-  apiKeyManager.updateRateLimit(existing.key, rateLimitPerMin);
+  apiKeyManager.updateRateLimit(req.params.keyHash, rateLimitPerMin);
   res.json({ success: true, data: { keyHash: req.params.keyHash, rateLimitPerMin } });
 });
 
@@ -186,7 +185,7 @@ router.post('/keys/:keyHash/revoke', (req: Request, res: Response) => {
     });
   }
 
-  apiKeyManager.revokeKey(existing.key);
+  apiKeyManager.revokeKey(req.params.keyHash);
   logger.info(`Admin ${req.apiKey?.substring(0, 8)}... revoked key ${req.params.keyHash}`);
 
   // Publish ApiKeyRevokedEvent
@@ -210,7 +209,7 @@ router.post('/keys/:keyHash/reactivate', (req: Request, res: Response) => {
     });
   }
 
-  apiKeyManager.reactivateKey(existing.key);
+  apiKeyManager.reactivateKey(req.params.keyHash);
   logger.info(`Admin ${req.apiKey?.substring(0, 8)}... reactivated key ${req.params.keyHash}`);
   res.json({ success: true, data: { keyHash: req.params.keyHash, action: 'reactivated' } });
 });
@@ -224,7 +223,7 @@ router.delete('/keys/:keyHash', (req: Request, res: Response) => {
     });
   }
 
-  apiKeyManager.deleteKey(existing.key);
+  apiKeyManager.deleteKey(req.params.keyHash);
   logger.info(`Admin ${req.apiKey?.substring(0, 8)}... deleted key ${req.params.keyHash}`);
   res.json({ success: true, data: { keyHash: req.params.keyHash, action: 'deleted' } });
 });

--- a/api/src/governance/api-key-manager.ts
+++ b/api/src/governance/api-key-manager.ts
@@ -12,8 +12,9 @@ export const TIER_RATE_LIMITS: Record<KeyTier, number> = {
 };
 
 export interface ApiKeyMetadata {
-  key: string;
   keyHash: string;
+  /** Non-secret leading segment of the key, kept for display in admin listings */
+  keyPrefix: string;
   createdAt: number;
   lastUsed: number | null;
   requestCount: number;
@@ -26,11 +27,17 @@ export interface ApiKeyMetadata {
   rotationExpiresAt?: number;
 }
 
+/** Metadata plus the plaintext key, returned only when a key is created or rotated. */
+export interface GeneratedApiKey extends ApiKeyMetadata {
+  key: string;
+}
+
 export interface ApiKeyStore {
   [keyHash: string]: ApiKeyMetadata;
 }
 
 export class ApiKeyManager {
+  /** Keyed by SHA-256 hash of the API key — plaintext keys are never retained. */
   private keys: Map<string, ApiKeyMetadata> = new Map();
   private lastMinuteRequests: Map<string, number[]> = new Map();
 
@@ -38,12 +45,12 @@ export class ApiKeyManager {
     this.loadKeysFromEnv();
   }
 
-  generateKey(rateLimitPerMin: number = TIER_RATE_LIMITS.free, description?: string, tier: KeyTier = 'free', role: Role = 'viewer'): ApiKeyMetadata {
+  generateKey(rateLimitPerMin: number = TIER_RATE_LIMITS.free, description?: string, tier: KeyTier = 'free', role: Role = 'viewer'): GeneratedApiKey {
     const key = this.createKey(tier);
     const keyHash = this.hashKey(key);
     const metadata: ApiKeyMetadata = {
-      key,
       keyHash,
+      keyPrefix: key.substring(0, 12),
       createdAt: Date.now(),
       lastUsed: null,
       requestCount: 0,
@@ -54,14 +61,14 @@ export class ApiKeyManager {
       description,
     };
 
-    this.keys.set(key, metadata);
-    logger.info(`Generated new API key: ${key.substring(0, 8)}... tier=${tier} role=${role} limit=${rateLimitPerMin}/min`);
+    this.keys.set(keyHash, metadata);
+    logger.info(`Generated new API key: ${metadata.keyPrefix}... tier=${tier} role=${role} limit=${rateLimitPerMin}/min`);
 
-    return metadata;
+    return { ...metadata, key };
   }
 
   validateKey(key: string): { valid: boolean; metadata?: ApiKeyMetadata; error?: string } {
-    const metadata = this.keys.get(key);
+    const metadata = this.keys.get(this.hashKey(key));
 
     if (!metadata) {
       return { valid: false, error: 'Invalid API key' };
@@ -75,12 +82,13 @@ export class ApiKeyManager {
   }
 
   isAdminKey(key: string): boolean {
-    const metadata = this.keys.get(key);
+    const metadata = this.keys.get(this.hashKey(key));
     return !!metadata && metadata.role === 'admin';
   }
 
   checkRateLimit(key: string): { allowed: boolean; remaining: number; resetTime: number; retryAfter?: number } {
-    const metadata = this.keys.get(key);
+    const keyHash = this.hashKey(key);
+    const metadata = this.keys.get(keyHash);
     if (!metadata) {
       return { allowed: false, remaining: 0, resetTime: 0 };
     }
@@ -89,7 +97,7 @@ export class ApiKeyManager {
     const windowMs = 60000;
     const oneMinuteAgo = now - windowMs;
 
-    let requests = this.lastMinuteRequests.get(key) || [];
+    let requests = this.lastMinuteRequests.get(keyHash) || [];
     requests = requests.filter((ts) => ts > oneMinuteAgo);
 
     if (requests.length >= metadata.rateLimitPerMin) {
@@ -101,7 +109,7 @@ export class ApiKeyManager {
     }
 
     requests.push(now);
-    this.lastMinuteRequests.set(key, requests);
+    this.lastMinuteRequests.set(keyHash, requests);
 
     metadata.lastUsed = now;
     metadata.requestCount++;
@@ -110,58 +118,58 @@ export class ApiKeyManager {
     return { allowed: true, remaining, resetTime: now + windowMs };
   }
 
-  rotateKey(oldKey: string): ApiKeyMetadata | null {
-    const metadata = this.keys.get(oldKey);
+  rotateKey(oldKeyHash: string): GeneratedApiKey | null {
+    const metadata = this.keys.get(oldKeyHash);
     if (!metadata) return null;
 
     const newKey = this.createKey(metadata.tier);
     const newHash = this.hashKey(newKey);
     const newMetadata: ApiKeyMetadata = {
       ...metadata,
-      key: newKey,
       keyHash: newHash,
+      keyPrefix: newKey.substring(0, 12),
       createdAt: Date.now(),
       lastUsed: null,
       requestCount: 0,
     };
 
-    this.keys.delete(oldKey);
-    this.lastMinuteRequests.delete(oldKey);
-    this.keys.set(newKey, newMetadata);
-    logger.info(`Rotated API key: old=${oldKey.substring(0, 8)}... new=${newKey.substring(0, 8)}...`);
+    this.keys.delete(oldKeyHash);
+    this.lastMinuteRequests.delete(oldKeyHash);
+    this.keys.set(newHash, newMetadata);
+    logger.info(`Rotated API key: old=${metadata.keyPrefix}... new=${newMetadata.keyPrefix}...`);
 
-    return newMetadata;
+    return { ...newMetadata, key: newKey };
   }
 
-  revokeKey(key: string): boolean {
-    const metadata = this.keys.get(key);
+  revokeKey(keyHash: string): boolean {
+    const metadata = this.keys.get(keyHash);
     if (!metadata) return false;
 
     metadata.isActive = false;
-    logger.info(`Revoked API key: ${key.substring(0, 8)}...`);
+    logger.info(`Revoked API key: ${metadata.keyPrefix}...`);
     return true;
   }
 
-  deactivateKey(key: string): boolean {
-    return this.revokeKey(key);
+  deactivateKey(keyHash: string): boolean {
+    return this.revokeKey(keyHash);
   }
 
-  reactivateKey(key: string): boolean {
-    const metadata = this.keys.get(key);
+  reactivateKey(keyHash: string): boolean {
+    const metadata = this.keys.get(keyHash);
     if (!metadata) return false;
 
     metadata.isActive = true;
-    logger.info(`Reactivated API key: ${key.substring(0, 8)}...`);
+    logger.info(`Reactivated API key: ${metadata.keyPrefix}...`);
     return true;
   }
 
-  getKeyMetadata(key: string): ApiKeyMetadata | null {
-    return this.keys.get(key) || null;
+  getKeyMetadata(keyHash: string): ApiKeyMetadata | null {
+    return this.keys.get(keyHash) || null;
   }
 
   getAllKeys(): Array<{ keyPrefix: string; keyHash: string; createdAt: number; lastUsed: number | null; requestCount: number; isActive: boolean; rateLimitPerMin: number; tier: KeyTier; role: Role; description?: string }> {
     return Array.from(this.keys.values()).map((m) => ({
-      keyPrefix: m.key.substring(0, 12) + '...',
+      keyPrefix: m.keyPrefix + '...',
       keyHash: m.keyHash,
       createdAt: m.createdAt,
       lastUsed: m.lastUsed,
@@ -175,33 +183,34 @@ export class ApiKeyManager {
   }
 
   findByHash(hash: string): ApiKeyMetadata | null {
-    return Array.from(this.keys.values()).find((m) => m.keyHash === hash) || null;
+    return this.keys.get(hash) || null;
   }
 
-  updateRateLimit(key: string, newLimit: number): boolean {
-    const metadata = this.keys.get(key);
+  updateRateLimit(keyHash: string, newLimit: number): boolean {
+    const metadata = this.keys.get(keyHash);
     if (!metadata) return false;
 
     metadata.rateLimitPerMin = newLimit;
-    logger.info(`Updated rate limit for ${key.substring(0, 8)}... to ${newLimit}/min`);
+    logger.info(`Updated rate limit for ${metadata.keyPrefix}... to ${newLimit}/min`);
     return true;
   }
 
-  updateTier(key: string, tier: KeyTier): boolean {
-    const metadata = this.keys.get(key);
+  updateTier(keyHash: string, tier: KeyTier): boolean {
+    const metadata = this.keys.get(keyHash);
     if (!metadata) return false;
 
     metadata.tier = tier;
     metadata.rateLimitPerMin = TIER_RATE_LIMITS[tier];
-    logger.info(`Updated tier for ${key.substring(0, 8)}... to ${tier} (${TIER_RATE_LIMITS[tier]}/min)`);
+    logger.info(`Updated tier for ${metadata.keyPrefix}... to ${tier} (${TIER_RATE_LIMITS[tier]}/min)`);
     return true;
   }
 
-  deleteKey(key: string): boolean {
-    const result = this.keys.delete(key);
+  deleteKey(keyHash: string): boolean {
+    const metadata = this.keys.get(keyHash);
+    const result = this.keys.delete(keyHash);
     if (result) {
-      this.lastMinuteRequests.delete(key);
-      logger.info(`Deleted API key: ${key.substring(0, 8)}...`);
+      this.lastMinuteRequests.delete(keyHash);
+      logger.info(`Deleted API key: ${metadata!.keyPrefix}...`);
     }
     return result;
   }
@@ -237,9 +246,10 @@ export class ApiKeyManager {
           const tier = (parts[3] as KeyTier) || 'free';
           const role = (parts[4] as Role) || 'viewer';
 
+          const keyHash = this.hashKey(key);
           const metadata: ApiKeyMetadata = {
-            key,
-            keyHash: this.hashKey(key),
+            keyHash,
+            keyPrefix: key.substring(0, 12),
             createdAt: Date.now(),
             lastUsed: null,
             requestCount: 0,
@@ -250,7 +260,7 @@ export class ApiKeyManager {
             description,
           };
 
-          this.keys.set(key, metadata);
+          this.keys.set(keyHash, metadata);
         }
       }
 

--- a/contracts/price-oracle/src/contract.rs
+++ b/contracts/price-oracle/src/contract.rs
@@ -3,7 +3,7 @@ use soroban_sdk::{contract, contractimpl, Address, Bytes, Env, String, Vec};
 use crate::errors::OracleError;
 use crate::merkle;
 use crate::storage;
-use crate::types::{AssetPrice, MultiSigConfig, Proposal, ProposalAction, PriceDataPoint, SourceReputation};
+use crate::types::{AssetPrice, BatchPriceEntry, MerkleProof, MultiSigConfig, Proposal, ProposalAction, PriceDataPoint, SourceReputation};
 
 // Basis points threshold below which a submission is counted as accurate for reputation.
 const REPUTATION_ACCURACY_THRESHOLD_BPS: u128 = 2000; // 20%
@@ -68,25 +68,26 @@ impl PriceOracleContract {
         Ok(data_point)
     }
 
-        // Cap history at MAX_HISTORY_LEN to keep persistent-storage entry size
-        // bounded.  Evict the oldest entry when the cap is reached rather than
-        // reading, appending, and writing the full vector unconditionally.
-        let mut history = storage::get_price_history(&env, &asset);
-        if history.len() >= MAX_HISTORY_LEN {
-            // Drop the oldest entry (index 0) by rebuilding from index 1.
-            // Soroban Vec has no remove(), so we shift manually.
-            let mut trimmed: Vec<PriceDataPoint> = Vec::new(&env);
-            for i in 1..history.len() {
-                if let Some(dp) = history.get(i) {
-                    trimmed.push_back(dp);
-                }
-            }
-            trimmed.push_back(data_point.clone());
-            storage::set_price_history(&env, &asset, &trimmed);
-        } else {
-            history.push_back(data_point.clone());
-            storage::set_price_history(&env, &asset, &history);
-        }
+    // -------------------------------------------------------------------------
+    // Issue #75 — Merkle batch submission
+    // -------------------------------------------------------------------------
+
+    /// Commit a Merkle root covering a batch of price entries.
+    ///
+    /// The authorized source submits one transaction with the root hash of an
+    /// ordered batch.  Individual entries are applied later via
+    /// `apply_batch_entry` using inclusion proofs — one cheap tx per price
+    /// instead of one full auth+storage tx per price.
+    ///
+    /// `nonce` must equal the current BatchNonce (prevents replay attacks).
+    /// Returns the new nonce after this batch.
+    pub fn submit_batch(
+        env: Env,
+        source: Address,
+        nonce: u64,
+        root: Bytes,
+    ) -> Result<u64, OracleError> {
+        source.require_auth();
 
         if !storage::is_authorized_source(&env, &source) {
             return Err(OracleError::UnauthorizedSource);
@@ -379,6 +380,30 @@ impl PriceOracleContract {
         storage::verify_admin(&env, &admin)?;
         storage::set_trusted_asset(&env, &asset, trusted);
         Ok(())
+    }
+}
+
+// -------------------------------------------------------------------------
+// History helper
+// Appends a data point to an asset's price history, capping it at
+// storage::MAX_HISTORY_LEN to keep the persistent-storage entry size bounded.
+// -------------------------------------------------------------------------
+fn append_history(env: &Env, asset: &String, data_point: PriceDataPoint) {
+    let mut history = storage::get_price_history(env, asset);
+    if history.len() >= storage::MAX_HISTORY_LEN {
+        // Drop the oldest entry (index 0) by rebuilding from index 1.
+        // Soroban Vec has no remove(), so we shift manually.
+        let mut trimmed: Vec<PriceDataPoint> = Vec::new(env);
+        for i in 1..history.len() {
+            if let Some(dp) = history.get(i) {
+                trimmed.push_back(dp);
+            }
+        }
+        trimmed.push_back(data_point);
+        storage::set_price_history(env, asset, &trimmed);
+    } else {
+        history.push_back(data_point);
+        storage::set_price_history(env, asset, &history);
     }
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,12 +83,6 @@ services:
       timeout: 10s
       retries: 3
 
-healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/v1/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-
   # --- PASTE THE VAULT CONTAINER INTEGRATION HERE ---
   vault:
     image: hashicorp/vault:1.15.2

--- a/services/aggregator/src/infrastructure/config.ts
+++ b/services/aggregator/src/infrastructure/config.ts
@@ -74,6 +74,13 @@ export const config = {
     retentionDays: parseInt(process.env.HISTORY_RETENTION_DAYS || '0', 10),
   },
 
+  // Caps applied to file-based history on every append (issue #214), so the
+  // JSON files under data/ cannot grow without bound. Set either to 0 to disable.
+  history: {
+    maxEntries: parseInt(process.env.HISTORY_MAX_ENTRIES || '10000', 10),
+    retentionSeconds: parseInt(process.env.HISTORY_RETENTION_SECONDS || '604800', 10),
+  },
+
   security: {
     // SSRF protection for outbound oracle-source HTTP requests (issue #39).
     ssrf: {

--- a/services/aggregator/src/persistence/history.ts
+++ b/services/aggregator/src/persistence/history.ts
@@ -31,6 +31,22 @@ function writeHistoryFile(filePath: string, history: any[]): void {
   fs.writeFileSync(filePath, payload);
 }
 
+/**
+ * Drop entries older than the retention window, then keep only the newest
+ * maxEntries (issue #214). Entry timestamps are Unix seconds.
+ */
+function pruneHistory(history: any[]): any[] {
+  const { maxEntries, retentionSeconds } = config.history;
+  let pruned = history;
+
+  if (retentionSeconds > 0) {
+    const cutoff = Math.floor(Date.now() / 1000) - retentionSeconds;
+    pruned = pruned.filter((h: any) => h.timestamp >= cutoff);
+  }
+
+  return maxEntries > 0 && pruned.length > maxEntries ? pruned.slice(-maxEntries) : pruned;
+}
+
 export function appendHistoricalPrice(
   asset: string,
   price: string,
@@ -45,7 +61,7 @@ export function appendHistoricalPrice(
     history = readHistoryFile(filePath);
   } catch { /* ignore corrupt data */ }
   history.push({ price, decimals, source, timestamp });
-  writeHistoryFile(filePath, history);
+  writeHistoryFile(filePath, pruneHistory(history));
 }
 
 export function getHistoricalPrices(


### PR DESCRIPTION

- **#211** — `api/src/governance/api-key-manager.ts` indexed the in-memory `keys` Map by the raw API key, so a memory dump exposed every key in plaintext. The Map is now keyed by the SHA-256 hash; `validateKey`/`isAdminKey`/`checkRateLimit` hash the incoming key before lookup, and the rate-limit Map is keyed by hash too. `ApiKeyMetadata.key` is gone — the plaintext is returned only from `generateKey`/`rotateKey` (new `GeneratedApiKey` type) and never retained. A non-secret `keyPrefix` (first 12 chars) is stored so the admin key listing keeps its existing output. Admin routes that already had the hash from the URL now pass `req.params.keyHash` straight through instead of the no-longer-stored `existing.key`.
- **#212** — `contracts/price-oracle/src/contract.rs` called `append_history()` at two call sites without defining it. Defined it as a module-level helper built from the previously unreachable trimming code, using `storage::MAX_HISTORY_LEN`. That orphaned block had been pasted over the `submit_batch` signature, so its doc comment, signature and `source.require_auth()` are restored — without that the file does not parse at all, and the missing `BatchPriceEntry`/`MerkleProof` type imports are added back.
- **#213** — `docker-compose.yml` had a stray top-level `healthcheck:` block (a copy of the `api` service's) sitting between `api` and `vault`. Removed. The `api` service keeps its own healthcheck.
- **#214** — `services/aggregator/src/persistence/history.ts` appended to each asset's JSON file forever. `appendHistoricalPrice` now prunes on write: entries outside the retention window are dropped, then the newest `maxEntries` are kept. Tunable via `HISTORY_MAX_ENTRIES` (default 10000) and `HISTORY_RETENTION_SECONDS` (default 7 days), either set to 0 to disable, following the existing config conventions. Entry timestamps are Unix seconds, matching what the oracle sources emit.

Closes #211
Closes #212
Closes #213
Closes #214
