### PR TITLE
feat(api): harden websocket signing and config secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,13 +115,15 @@ WS_CSRF_TTL_MS=300000
 
 # HMAC signing for WebSocket connections (Issue #35).
 # When set, clients must pass ?ts=<epoch_ms>&nonce=<uuid>&sig=<hmac-sha256>
-# on the WS URL. See api/src/middleware/ws-signing.ts for signing details.
+# on the WS URL. Sign the string "<ts>.<nonce>." with WS_HMAC_SECRET using
+# HMAC-SHA256 and hex encoding.
 WS_HMAC_SECRET=
 
 # === Encryption at Rest (Issue #41) ===
 # 32-byte key as 64 hex chars (generate with: tsx scripts/encrypt-secret.ts genkey).
 # When set, sensitive env values stored as `enc:...` payloads are decrypted at
-# startup, and historical price files can be encrypted at rest.
+# startup, including API keys, database URLs, Redis URLs, WebSocket secrets,
+# audit secrets, backup keys, and alert/webhook secrets.
 ENCRYPTION_KEY=
 # During key rotation, keep the previous key here so old data still decrypts.
 ENCRYPTION_KEY_PREVIOUS=

--- a/api/docs/SECURITY.md
+++ b/api/docs/SECURITY.md
@@ -60,6 +60,9 @@ Controls:
 - **CSRF tokens (API)** — when `WS_CSRF_SECRET` is set, clients must obtain a
   short-lived token from `GET /api/v1/ws-token` and present it as `?token=<token>`
   on the WebSocket URL. Tokens are HMAC-signed and time-bound.
+- **HMAC signing (API)** — when `WS_HMAC_SECRET` is set, clients must sign the
+  upgrade URL with `?ts=<epoch_ms>&nonce=<unique-id>&sig=<hex-hmac>`.
+  Verification runs before the WebSocket upgrade is accepted.
 - **Logging** — every rejected upgrade is logged with the client IP, origin, and
   reason.
 
@@ -72,6 +75,7 @@ WS_RATE_LIMIT_MAX=20
 WS_RATE_LIMIT_WINDOW_MS=60000
 WS_CSRF_SECRET=<random-secret>     # enables CSRF tokens when set
 WS_CSRF_TTL_MS=300000
+WS_HMAC_SECRET=<random-secret>     # enables signed WS upgrades when set
 ```
 
 Client flow with CSRF enabled:
@@ -80,6 +84,25 @@ Client flow with CSRF enabled:
 const { data } = await fetch('/api/v1/ws-token').then((r) => r.json());
 const ws = new WebSocket(`wss://host:3001/?token=${data.token}`);
 ```
+
+Client flow with HMAC enabled:
+
+```js
+import crypto from 'node:crypto';
+
+const ts = Date.now();
+const nonce = crypto.randomUUID();
+const sig = crypto
+  .createHmac('sha256', process.env.WS_HMAC_SECRET)
+  .update(`${ts}.${nonce}.`)
+  .digest('hex');
+
+const ws = new WebSocket(`wss://host:3001/?ts=${ts}&nonce=${nonce}&sig=${sig}`);
+```
+
+The timestamp must be within 30 seconds of server time. Nonces are single-use
+inside that window to reject replayed upgrade URLs. If CSRF and HMAC are both
+enabled, include `token`, `ts`, `nonce`, and `sig` in the same query string.
 
 ---
 
@@ -115,9 +138,12 @@ data encrypted by one decrypts in the other.
    # -> enc:v1:<keyId>:<iv>:<tag>:<ciphertext>
    ```
 
-4. Store the `enc:` payload in `.env` (works for `ADMIN_SECRET_KEY`,
-   `CHAINLINK_API_KEY`, `DATABASE_URL`). The services decrypt it automatically at
-   startup. Plaintext values still work, so migration can be incremental.
+4. Store the `enc:` payload in `.env`. Sensitive values such as
+   `ADMIN_SECRET_KEY`, `ADMIN_API_KEY`, `API_KEYS`, `DATABASE_URL`,
+   `DATABASE_REPLICA_URLS`, `REDIS_URL`, WebSocket secrets, audit secrets,
+   backup encryption keys, oracle API keys, and alert/webhook secrets are
+   decrypted automatically at startup. Plaintext values still work, so migration
+   can be incremental.
 
 ### Encrypting historical data
 

--- a/api/src/governance/api-key-manager.ts
+++ b/api/src/governance/api-key-manager.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import { logger } from '../observability/logger';
 import type { Role } from './rbac';
+import { decryptSecret } from './crypto';
 
 export type KeyTier = 'free' | 'pro' | 'enterprise' | 'admin';
 
@@ -225,7 +226,7 @@ export class ApiKeyManager {
   }
 
   private loadKeysFromEnv(): void {
-    const envKeys = process.env.API_KEYS;
+    const envKeys = process.env.API_KEYS ? decryptSecret(process.env.API_KEYS) : undefined;
     if (!envKeys) {
       if (this.keys.size === 0) {
         const adminKey = this.generateKey(TIER_RATE_LIMITS.admin, 'Default admin key', 'admin', 'admin');

--- a/api/src/governance/audit-logger.ts
+++ b/api/src/governance/audit-logger.ts
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 import winston from 'winston';
+import { decryptSecret } from './crypto';
 
 export type AuditEvent =
   | 'auth.success'
@@ -33,7 +34,9 @@ interface AuditEntry {
   hmac: string;
 }
 
-const AUDIT_SECRET = process.env.AUDIT_SECRET || 'default-audit-secret-change-in-prod';
+const AUDIT_SECRET = process.env.AUDIT_SECRET
+  ? decryptSecret(process.env.AUDIT_SECRET)
+  : 'default-audit-secret-change-in-prod';
 
 const auditFileLogger = winston.createLogger({
   level: 'info',

--- a/api/src/governance/auth.ts
+++ b/api/src/governance/auth.ts
@@ -4,6 +4,7 @@ import { apiKeyManager } from './api-key-manager';
 import { logger } from '../observability/logger';
 import { auditLog } from './audit-logger';
 import type { Role } from './rbac';
+import { decryptSecret } from './crypto';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -135,7 +136,8 @@ export function adminAuthMiddleware(_adminKeyPrefix: string) {
       return;
     }
 
-    const isAdmin = apiKeyManager.isAdminKey(apiKey) || process.env.ADMIN_API_KEY === apiKey;
+    const adminApiKey = process.env.ADMIN_API_KEY ? decryptSecret(process.env.ADMIN_API_KEY) : '';
+    const isAdmin = apiKeyManager.isAdminKey(apiKey) || adminApiKey === apiKey;
     if (!isAdmin) {
       logger.warn(`Unauthorized admin access: ${apiKey.substring(0, 8)}...`);
       res.status(403).json({
@@ -153,7 +155,6 @@ export function adminAuthMiddleware(_adminKeyPrefix: string) {
 
 export function optionalAuthMiddleware(req: Request, res: Response, next: NextFunction): void {
   const apiKey = extractApiKey(req);
-  const ctx = requestContext(req);
 
   if (!apiKey) {
     next();

--- a/api/src/infrastructure/config.ts
+++ b/api/src/infrastructure/config.ts
@@ -4,10 +4,20 @@ import { decryptSecret } from '../governance/crypto';
 
 dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 
+export function secretEnv(name: string, fallback = ''): string {
+  const value = process.env[name];
+  return value ? decryptSecret(value) : fallback;
+}
+
+export function optionalSecretEnv(name: string): string | undefined {
+  const value = process.env[name];
+  return value ? decryptSecret(value) : undefined;
+}
+
 export const config = {
   sandbox: {
     enabled: process.env.SANDBOX_ENABLED === 'true',
-    resetToken: process.env.SANDBOX_RESET_TOKEN || '',
+    resetToken: secretEnv('SANDBOX_RESET_TOKEN'),
   },
   port: parseInt(process.env.API_PORT || '3000', 10),
   wsPort: parseInt(process.env.WS_PORT || '3001', 10),
@@ -19,13 +29,13 @@ export const config = {
   rateLimitWindowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS || '60000', 10),
   rateLimitMax: parseInt(process.env.RATE_LIMIT_MAX || '100', 10),
   cacheTtlMs: parseInt(process.env.CACHE_TTL_MS || '15000', 10),
-  redisUrl: process.env.REDIS_URL,
+  redisUrl: optionalSecretEnv('REDIS_URL'),
   priceCacheTtl: parseInt(process.env.PRICE_CACHE_TTL_MS || '15000', 10),
   historyCacheTtl: parseInt(process.env.HISTORY_CACHE_TTL_MS || '60000', 10),
   sourcesCacheTtl: parseInt(process.env.SOURCES_CACHE_TTL_MS || '300000', 10),
   healthCacheTtl: parseInt(process.env.HEALTH_CACHE_TTL_MS || '30000', 10),
   // Sensitive: decrypted at rest if stored as an `enc:` payload (issue #41).
-  databaseUrl: process.env.DATABASE_URL ? decryptSecret(process.env.DATABASE_URL) : undefined,
+  databaseUrl: optionalSecretEnv('DATABASE_URL'),
   // TimescaleDB hypertable support (issue #42).
   useTimescale: process.env.USE_TIMESCALEDB !== 'false',
   // Connection pooling, retry and circuit breaker (issue #44).
@@ -77,11 +87,11 @@ export const config = {
       .map((o) => o.trim())
       .filter(Boolean),
     requireOrigin: process.env.WS_REQUIRE_ORIGIN !== 'false',
-    csrfSecret: process.env.WS_CSRF_SECRET || '',
+    csrfSecret: secretEnv('WS_CSRF_SECRET'),
     csrfTtlMs: parseInt(process.env.WS_CSRF_TTL_MS || '300000', 10),
     rateLimitMax: parseInt(process.env.WS_RATE_LIMIT_MAX || '20', 10),
     rateLimitWindowMs: parseInt(process.env.WS_RATE_LIMIT_WINDOW_MS || '60000', 10),
-    hmacSecret: process.env.WS_HMAC_SECRET || '',
+    hmacSecret: secretEnv('WS_HMAC_SECRET'),
   },
   // Encryption at rest for sensitive config + historical data (issue #41).
   encryption: {
@@ -98,7 +108,7 @@ export const config = {
     enabled: process.env.BACKUP_ENABLED === 'true',
     dir: process.env.BACKUP_DIR || './data/backups',
     // 64-char hex key; if omitted backups are stored unencrypted
-    encryptionKeyHex: process.env.BACKUP_ENCRYPTION_KEY || '',
+    encryptionKeyHex: secretEnv('BACKUP_ENCRYPTION_KEY'),
   },
   consistency: {
     enabled: process.env.CONSISTENCY_CHECK_ENABLED !== 'false',

--- a/api/src/infrastructure/server.ts
+++ b/api/src/infrastructure/server.ts
@@ -4,9 +4,9 @@ import { logger } from '../observability/logger';
 import { validateWebSocketApiKey } from '../governance/auth';
 import { HybridCache } from '../price-serving/cache';
 import { validateWsAssets } from '../governance/sanitization';
-import { verifyWsSignature } from '../governance/ws-signing';
 import { webhookService } from '../webhooks/webhook-service';
 import { config } from './config';
+import { WsUpgradeGuard } from './upgrade-guard';
 import {
   wsConnectionsActive,
   wsConnectionsTotal,
@@ -47,20 +47,14 @@ export class PriceWebSocketServer {
   }
 
   start(): void {
-    this.wss = new WsServer({ port: this.port, clientTracking: false });
+    const guard = new WsUpgradeGuard();
+    this.wss = new WsServer({ port: this.port, clientTracking: false, verifyClient: guard.verifyClient });
 
     this.wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
       const auth = validateWebSocketApiKey(req);
       if (!auth.valid) {
         ws.send(JSON.stringify({ type: 'error', code: 'UNAUTHORIZED', message: auth.error }));
         ws.close(1008, auth.error || 'Unauthorized');
-        return;
-      }
-
-      const sigCheck = verifyWsSignature(req, config.ws.hmacSecret);
-      if (!sigCheck.valid) {
-        ws.send(JSON.stringify({ type: 'error', code: 'SIGNATURE_INVALID', message: sigCheck.error }));
-        ws.close(1008, sigCheck.error || 'Invalid signature');
         return;
       }
 
@@ -108,6 +102,8 @@ export class PriceWebSocketServer {
     });
 
     logger.info(`WebSocket server on port ${this.port}`);
+
+    this.sweepTimer = setInterval(() => guard.sweep(), config.ws.rateLimitWindowMs);
   }
 
   private handleMessage(ws: WebSocket, msg: unknown): void {

--- a/api/src/infrastructure/upgrade-guard.ts
+++ b/api/src/infrastructure/upgrade-guard.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage } from 'http';
 import { config } from './config';
 import { logger } from '../observability/logger';
 import { verifyWsCsrfToken, isCsrfEnabled } from './csrf';
+import { verifyWsSignature } from '../governance/ws-signing';
 
 /**
  * Validates WebSocket upgrade requests before a connection is accepted
@@ -43,6 +44,13 @@ export class WsUpgradeGuard {
     if (!this.checkCsrf(info.req)) {
       this.deny(ip, origin, 'csrf');
       cb(false, 403, 'Invalid or missing CSRF token');
+      return;
+    }
+
+    const sigCheck = verifyWsSignature(info.req, config.ws.hmacSecret);
+    if (!sigCheck.valid) {
+      this.deny(ip, origin, 'hmac');
+      cb(false, 403, sigCheck.error || 'Invalid WebSocket signature');
       return;
     }
 

--- a/api/tests/db-circuit-breaker.test.ts
+++ b/api/tests/db-circuit-breaker.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest';
+import { CircuitOpenError, DbCircuitBreaker } from '../src/infrastructure/db-circuit-breaker';
+
+const config = {
+  enabled: true,
+  failureThreshold: 2,
+  successThreshold: 2,
+  openMs: 1_000,
+};
+
+describe('DbCircuitBreaker', () => {
+  it('opens after the configured failure threshold and fails fast while open', async () => {
+    let now = 0;
+    const logger = { error: vi.fn(), warn: vi.fn(), info: vi.fn() } as any;
+    const breaker = new DbCircuitBreaker('primary', config, logger, () => now);
+    const error = new Error('db down');
+
+    await expect(breaker.execute(() => Promise.reject(error))).rejects.toBe(error);
+    await expect(breaker.execute(() => Promise.reject(error))).rejects.toBe(error);
+
+    expect(breaker.getState()).toBe('open');
+    expect(breaker.getStateCode()).toBe(2);
+    expect(logger.error).toHaveBeenCalledWith('Database circuit breaker "primary" opened');
+    await expect(breaker.execute(() => Promise.resolve('skipped'))).rejects.toBeInstanceOf(CircuitOpenError);
+
+    now = 999;
+    await expect(breaker.execute(() => Promise.resolve('still skipped'))).rejects.toBeInstanceOf(CircuitOpenError);
+  });
+
+  it('moves half-open after open timeout and closes after enough successful probes', async () => {
+    let now = 0;
+    const logger = { error: vi.fn(), warn: vi.fn(), info: vi.fn() } as any;
+    const breaker = new DbCircuitBreaker('replica', config, logger, () => now);
+
+    await expect(breaker.execute(() => Promise.reject(new Error('one')))).rejects.toThrow('one');
+    await expect(breaker.execute(() => Promise.reject(new Error('two')))).rejects.toThrow('two');
+
+    now = 1_000;
+    await expect(breaker.execute(() => Promise.resolve('probe-1'))).resolves.toBe('probe-1');
+    expect(breaker.getState()).toBe('half-open');
+    expect(breaker.getStateCode()).toBe(1);
+
+    await expect(breaker.execute(() => Promise.resolve('probe-2'))).resolves.toBe('probe-2');
+    expect(breaker.getState()).toBe('closed');
+    expect(breaker.getStateCode()).toBe(0);
+    expect(logger.warn).toHaveBeenCalledWith('Database circuit breaker "replica" half-open (probing)');
+    expect(logger.info).toHaveBeenCalledWith('Database circuit breaker "replica" closed');
+  });
+
+  it('reopens immediately when a half-open probe fails', async () => {
+    let now = 0;
+    const breaker = new DbCircuitBreaker('replica', config, undefined, () => now);
+
+    await expect(breaker.execute(() => Promise.reject(new Error('one')))).rejects.toThrow('one');
+    await expect(breaker.execute(() => Promise.reject(new Error('two')))).rejects.toThrow('two');
+
+    now = 1_000;
+    await expect(breaker.execute(() => Promise.reject(new Error('probe failed')))).rejects.toThrow('probe failed');
+
+    expect(breaker.getState()).toBe('open');
+    expect(breaker.getStateCode()).toBe(2);
+  });
+
+  it('bypasses state tracking when disabled', async () => {
+    const breaker = new DbCircuitBreaker('disabled', { ...config, enabled: false });
+
+    await expect(breaker.execute(() => Promise.resolve('ok'))).resolves.toBe('ok');
+    await expect(breaker.execute(() => Promise.reject(new Error('fail')))).rejects.toThrow('fail');
+
+    expect(breaker.getState()).toBe('closed');
+    expect(breaker.getStateCode()).toBe(0);
+  });
+});

--- a/api/tests/db-retry.test.ts
+++ b/api/tests/db-retry.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { isTransientError, withRetry } from '../src/infrastructure/db-retry';
+
+describe('db retry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('retries transient failures with exponential backoff and jitter', async () => {
+    const operation = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error('connection reset'), { code: 'ECONNRESET' }))
+      .mockRejectedValueOnce(Object.assign(new Error('deadlock'), { code: '40P01' }))
+      .mockResolvedValue('ok');
+    const logger = { warn: vi.fn() } as any;
+
+    const promise = withRetry(operation, { maxRetries: 3, baseDelayMs: 100, maxDelayMs: 1_000 }, logger);
+
+    await vi.advanceTimersByTimeAsync(50);
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expect(promise).resolves.toBe('ok');
+    expect(operation).toHaveBeenCalledTimes(3);
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops after max retries', async () => {
+    const error = Object.assign(new Error('timeout'), { code: 'ETIMEDOUT' });
+    const operation = vi.fn().mockRejectedValue(error);
+
+    const promise = withRetry(operation, { maxRetries: 2, baseDelayMs: 10, maxDelayMs: 100 });
+    const assertion = expect(promise).rejects.toBe(error);
+
+    await vi.runAllTimersAsync();
+    await assertion;
+    expect(operation).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry deterministic database errors', async () => {
+    const error = Object.assign(new Error('duplicate key'), { code: '23505' });
+    const operation = vi.fn().mockRejectedValue(error);
+
+    await expect(withRetry(operation, { maxRetries: 3, baseDelayMs: 10, maxDelayMs: 100 })).rejects.toBe(error);
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it('classifies transient postgres, system, and timeout message errors', () => {
+    expect(isTransientError({ code: '08006' })).toBe(true);
+    expect(isTransientError({ code: 'ECONNREFUSED' })).toBe(true);
+    expect(isTransientError(new Error('pool connection timeout'))).toBe(true);
+    expect(isTransientError({ code: '23505' })).toBe(false);
+  });
+});

--- a/services/aggregator/src/index.ts
+++ b/services/aggregator/src/index.ts
@@ -12,6 +12,7 @@ import { HealthServer } from './observability/health-server';
 import AlertManager from './observability/alert-manager';
 import { sourceCircuitBreaker } from './price-aggregation/source-circuit-breaker';
 import { eventBus } from './domain-events';
+import { decryptSecret } from './infrastructure/crypto';
 
 // In-process counters surfaced as structured log lines; the API /metrics
 // endpoint (prom-client) collects the canonical Prometheus metrics.
@@ -32,10 +33,10 @@ function incAnomaly(asset: string, method: string): void {
 
 const aggregator = new PriceAggregator();
 const alertManager = new AlertManager({
-  webhookUrl: process.env.ALERT_WEBHOOK_URL,
-  slackWebhookUrl: process.env.ALERT_SLACK_WEBHOOK_URL,
-  pagerDutyRoutingKey: process.env.ALERT_PAGERDUTY_ROUTING_KEY,
-  emailWebhookUrl: process.env.ALERT_EMAIL_WEBHOOK_URL,
+  webhookUrl: process.env.ALERT_WEBHOOK_URL ? decryptSecret(process.env.ALERT_WEBHOOK_URL) : undefined,
+  slackWebhookUrl: process.env.ALERT_SLACK_WEBHOOK_URL ? decryptSecret(process.env.ALERT_SLACK_WEBHOOK_URL) : undefined,
+  pagerDutyRoutingKey: process.env.ALERT_PAGERDUTY_ROUTING_KEY ? decryptSecret(process.env.ALERT_PAGERDUTY_ROUTING_KEY) : undefined,
+  emailWebhookUrl: process.env.ALERT_EMAIL_WEBHOOK_URL ? decryptSecret(process.env.ALERT_EMAIL_WEBHOOK_URL) : undefined,
   emailRecipients: (process.env.ALERT_EMAIL_RECIPIENTS || '').split(',').map((s) => s.trim()).filter(Boolean),
   sourceDisagreementThresholdPercent: parseFloat(process.env.ALERT_SOURCE_DISAGREEMENT_PERCENT || '5'),
 });


### PR DESCRIPTION
Summary:
- Enforce WebSocket HMAC signing during upgrade validation and document the client signing scheme.
- Extend enc: secret decryption to API keys, admin/audit/WS/cache/backup secrets, and aggregator alert webhook secrets.
- Add focused unit tests for database retry backoff/error classification and circuit breaker state transitions/state codes.

Closes #253
Closes #255
Closes #257
Closes #258

Validation performed:
- npm test -- tests/db-retry.test.ts tests/db-circuit-breaker.test.ts (api) — passed
- npx eslint src/infrastructure/config.ts src/governance/api-key-manager.ts src/governance/auth.ts src/governance/audit-logger.ts src/infrastructure/upgrade-guard.ts src/infrastructure/server.ts (api) — passed with existing warnings only
- npx tsc --noEmit (services/aggregator) — passed

Known pre-existing validation failures:
- npm ci in api fails because api/package-lock.json is out of sync with api/package.json.
- npx tsc --noEmit / npm run build in api fails on unrelated existing errors: missing featureFlagRoutes/eventRoutes symbols and ../middleware/logger imports in eventStore/featureFlags.
- npm run lint in api fails on unrelated existing unused imports in admin/v1/index/eventStore plus existing warnings.