### PR TITLE
feat(api): add per-IP concurrent connection limiting to WS upgrade guard- #1

### DIFF
--- a/api/src/infrastructure/config.ts
+++ b/api/src/infrastructure/config.ts
@@ -96,6 +96,7 @@ export const config = {
     csrfTtlMs: parseInt(process.env.WS_CSRF_TTL_MS || '300000', 10),
     rateLimitMax: parseInt(process.env.WS_RATE_LIMIT_MAX || '20', 10),
     rateLimitWindowMs: parseInt(process.env.WS_RATE_LIMIT_WINDOW_MS || '60000', 10),
+    maxConcurrentConnectionsPerIp: parseInt(process.env.WS_MAX_CONCURRENT_CONNECTIONS_PER_IP || '10', 10),
     hmacSecret: secretEnv('WS_HMAC_SECRET'),
   },
   // Encryption at rest for sensitive config + historical data (issue #41).

--- a/api/src/infrastructure/server.ts
+++ b/api/src/infrastructure/server.ts
@@ -35,6 +35,7 @@ function nextSeq(): number {
 export class PriceWebSocketServer {
   private wss: WsServer | null = null;
   private port: number;
+  private guard: WsUpgradeGuard;
   private clients: Set<WebSocket> = new Set();
   private subscriptions: Map<WebSocket, Set<string>> = new Map();
   private cache: HybridCache<any> | null = null;
@@ -44,11 +45,11 @@ export class PriceWebSocketServer {
 
   constructor(port: number) {
     this.port = port;
+    this.guard = new WsUpgradeGuard();
   }
 
   start(): void {
-    const guard = new WsUpgradeGuard();
-    this.wss = new WsServer({ port: this.port, clientTracking: false, verifyClient: guard.verifyClient });
+    this.wss = new WsServer({ port: this.port, clientTracking: false, verifyClient: this.guard.verifyClient });
 
     this.wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
       const auth = validateWebSocketApiKey(req);
@@ -57,6 +58,9 @@ export class PriceWebSocketServer {
         ws.close(1008, auth.error || 'Unauthorized');
         return;
       }
+
+      const ip = this.clientIp(req);
+      this.guard.onConnect(ip);
 
       const connectedAt = Date.now();
       this.clients.add(ws);
@@ -78,6 +82,7 @@ export class PriceWebSocketServer {
       });
 
       ws.on('close', () => {
+        this.guard.onDisconnect(ip);
         this.clients.delete(ws);
         this.subscriptions.delete(ws);
         wsConnectionsActive.dec();
@@ -103,7 +108,7 @@ export class PriceWebSocketServer {
 
     logger.info(`WebSocket server on port ${this.port}`);
 
-    this.sweepTimer = setInterval(() => guard.sweep(), config.ws.rateLimitWindowMs);
+    this.sweepTimer = setInterval(() => this.guard.sweep(), config.ws.rateLimitWindowMs);
   }
 
   private handleMessage(ws: WebSocket, msg: unknown): void {
@@ -256,6 +261,14 @@ export class PriceWebSocketServer {
         logger.warn(`Cache invalidation failed for pattern ${pattern}: ${err}`);
       });
     });
+  }
+
+  private clientIp(req: IncomingMessage): string {
+    const forwarded = req.headers['x-forwarded-for'];
+    if (typeof forwarded === 'string' && forwarded.length > 0) {
+      return forwarded.split(',')[0].trim();
+    }
+    return req.socket.remoteAddress || 'unknown';
   }
 
   stop(): void {

--- a/api/src/infrastructure/upgrade-guard.ts
+++ b/api/src/infrastructure/upgrade-guard.ts
@@ -17,6 +17,7 @@ interface RateBucket {
 
 export class WsUpgradeGuard {
   private buckets = new Map<string, RateBucket>();
+  private connectionCounts = new Map<string, number>();
 
   /**
    * `verifyClient`-compatible callback for the `ws` server. Returns the
@@ -28,6 +29,12 @@ export class WsUpgradeGuard {
   ): void => {
     const ip = this.clientIp(info.req);
     const origin = info.origin;
+
+    if (!this.checkConcurrentConnections(ip)) {
+      this.deny(ip, origin, 'connection-flood');
+      cb(false, 429, 'Too many concurrent connections from this IP');
+      return;
+    }
 
     if (!this.checkRateLimit(ip)) {
       this.deny(ip, origin, 'rate-limit');
@@ -75,6 +82,25 @@ export class WsUpgradeGuard {
     if (!isCsrfEnabled()) return true;
     const token = this.queryParam(req, 'token');
     return verifyWsCsrfToken(token);
+  }
+
+  onConnect(ip: string): void {
+    const count = this.connectionCounts.get(ip) || 0;
+    this.connectionCounts.set(ip, count + 1);
+  }
+
+  onDisconnect(ip: string): void {
+    const count = this.connectionCounts.get(ip) || 0;
+    if (count <= 1) {
+      this.connectionCounts.delete(ip);
+    } else {
+      this.connectionCounts.set(ip, count - 1);
+    }
+  }
+
+  private checkConcurrentConnections(ip: string): boolean {
+    const count = this.connectionCounts.get(ip) || 0;
+    return count < config.ws.maxConcurrentConnectionsPerIp;
   }
 
   private checkRateLimit(ip: string): boolean {


### PR DESCRIPTION
Closes #267
Closes #268
Closes #269
Closes #270

## Summary
Adds per-IP concurrent connection limiting to the API WebSocket upgrade guard to prevent connection floods.

## Changes
- config.ts: new WS_MAX_CONCURRENT_CONNECTIONS_PER_IP env var (default 10)
- upgrade-guard.ts: connectionCounts map, checkConcurrentConnections, onConnect/onDisconnect methods, zero-count cleanup
- server.ts: guard stored as instance field, clientIp helper, onConnect after auth, onDisconnect on close

## How it works
The verifyClient callback now checks concurrent connections before rate-limit/origin/CSRF checks. When an IP hits the cap, upgrades are rejected with 429. The connection count is incremented after API key auth passes and decremented on connection close.

## Testing
- Existing websocket-rate-limiting tests pass (2 pre-existing failures unrelated)
- No new TypeScript errors introduced