### PR TITLE
feat: persist source uptime history and add automated SLA breach aler…

### DIFF
--- a/k8s/base/prometheus-rule.yaml
+++ b/k8s/base/prometheus-rule.yaml
@@ -1,0 +1,56 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: stellar-oracle-sla-alerts
+  labels:
+    app: stellar-price-oracle
+    component: aggregator
+spec:
+  groups:
+    - name: stellar-oracle.sla
+      interval: 1m
+      rules:
+        - alert: OracleSourceSlaBreachRateHigh
+          expr: |
+            rate(oracle_source_sla_breaches_total[5m]) > 0.05
+          for: 5m
+          labels:
+            severity: warning
+            component: aggregator
+          annotations:
+            summary: Oracle source SLA breach rate is elevated ({{ $labels.source }})
+            description: >
+              Source {{ $labels.source }} has an SLA breach rate of
+              {{ $value | humanize }}/s over the last 5 minutes.
+              The SLA threshold is 5 seconds per request.
+            runbook_url: https://github.com/Stellar-Unified-Price-Oracle/-Stellar-Unified-Price-Oracle-Aggregator-API-Backend/blob/main/docs/runbooks/oracle-source-down.md
+
+        - alert: OracleSourceSlaBreachRateCritical
+          expr: |
+            rate(oracle_source_sla_breaches_total[5m]) > 0.2
+          for: 3m
+          labels:
+            severity: critical
+            component: aggregator
+          annotations:
+            summary: Oracle source SLA breach rate is critical ({{ $labels.source }})
+            description: >
+              Source {{ $labels.source }} has a critical SLA breach rate of
+              {{ $value | humanize }}/s over the last 5 minutes.
+              Immediate investigation required.
+            runbook_url: https://github.com/Stellar-Unified-Price-Oracle/-Stellar-Unified-Price-Oracle-Aggregator-API-Backend/blob/main/docs/runbooks/oracle-source-down.md
+
+        - alert: OracleSourceUptimeDegraded
+          expr: |
+            last_over_time(oracle_source_uptime_percent{source!=""}[10m]) < 95
+          for: 10m
+          labels:
+            severity: warning
+            component: aggregator
+          annotations:
+            summary: Oracle source {{ $labels.source }} uptime has dropped below 95%
+            description: >
+              Source {{ $labels.source }} has an uptime of
+              {{ $value }}% over the last 10 minutes.
+              Check source health and circuit breaker status.
+            runbook_url: https://github.com/Stellar-Unified-Price-Oracle/-Stellar-Unified-Price-Oracle-Aggregator-API-Backend/blob/main/docs/runbooks/oracle-source-down.md

--- a/services/aggregator/src/domain-events/index.ts
+++ b/services/aggregator/src/domain-events/index.ts
@@ -5,7 +5,8 @@ export type DomainEvent =
   | PriceAggregatedEvent
   | PricePublishedEvent
   | AnomalyDetectedEvent
-  | SourceDegradedEvent;
+  | SourceDegradedEvent
+  | SlaBreachEvent;
 
 export interface PriceFetchedEvent {
   type: 'price_fetched';
@@ -39,6 +40,17 @@ export interface SourceDegradedEvent {
   payload: {
     source: string;
     reason: string;
+  };
+  timestamp: number;
+}
+
+export interface SlaBreachEvent {
+  type: 'sla_breach';
+  payload: {
+    source: string;
+    asset: string;
+    elapsedSeconds: number;
+    thresholdSeconds: number;
   };
   timestamp: number;
 }

--- a/services/aggregator/src/index.ts
+++ b/services/aggregator/src/index.ts
@@ -5,6 +5,8 @@ import { PriceAggregator } from './price-aggregation/aggregator';
 import { AggregatedPrice, NormalizedPrice } from './infrastructure/types';
 import { ContractPublisher } from './contract-publishing/publisher';
 import { appendHistoricalPrice } from './persistence/history';
+import { appendUptimeSnapshot } from './persistence/uptime-history';
+import { oracleSourceUptimePercent } from './observability/metrics';
 import { DatabaseClient } from './persistence/database';
 import { BaseSource } from './oracle-sources/base';
 import { WebSocketServer } from './infrastructure/ws-server';
@@ -39,6 +41,8 @@ const alertManager = new AlertManager({
   emailWebhookUrl: process.env.ALERT_EMAIL_WEBHOOK_URL ? decryptSecret(process.env.ALERT_EMAIL_WEBHOOK_URL) : undefined,
   emailRecipients: (process.env.ALERT_EMAIL_RECIPIENTS || '').split(',').map((s) => s.trim()).filter(Boolean),
   sourceDisagreementThresholdPercent: parseFloat(process.env.ALERT_SOURCE_DISAGREEMENT_PERCENT || '5'),
+  slaBreachMaxPerWindow: parseInt(process.env.ALERT_SLA_BREACH_MAX_PER_WINDOW || '10', 10),
+  slaBreachWindowSeconds: parseInt(process.env.ALERT_SLA_BREACH_WINDOW_SECONDS || '300', 10),
 });
 
 let lastAggregated: AggregatedPrice[] = [];
@@ -164,6 +168,12 @@ async function poll(): Promise<AggregatedPrice[]> {
   }
 
   lastAggregated = aggregated;
+
+  for (const source of sources) {
+    appendUptimeSnapshot(source.name, source.health);
+    oracleSourceUptimePercent.set({ source: source.name }, source.health.uptimePercent);
+  }
+
   return aggregated;
 }
 
@@ -199,6 +209,17 @@ async function main(): Promise<void> {
     reflector: new ReflectorSource(),
   };
   pollSources = Object.values(persistentSources);
+
+  // Subscribe to SLA breach events and route to alert manager
+  eventBus.subscribe('sla_breach', (event) => {
+    if (event.type === 'sla_breach') {
+      alertManager.checkSlaBreach(
+        event.payload.source,
+        event.payload.asset,
+        event.payload.elapsedSeconds,
+      );
+    }
+  });
 
   const healthServer = new HealthServer(config.port + 2, () => ({
     sourceHealth: {

--- a/services/aggregator/src/observability/alert-manager.ts
+++ b/services/aggregator/src/observability/alert-manager.ts
@@ -14,12 +14,15 @@ export interface AlertThresholds {
 export interface AlertEvent {
   timestamp: number;
   asset: string;
-  type: 'deviation' | 'stale' | 'source_down';
+  type: 'deviation' | 'stale' | 'source_down' | 'sla_breach';
   message: string;
   previousPrice?: string;
   currentPrice?: string;
   deviationPercent?: number;
   affectedSources?: string[];
+  source?: string;
+  elapsedSeconds?: number;
+  thresholdSeconds?: number;
 }
 
 export interface AlertConfig {
@@ -38,6 +41,12 @@ export interface AlertConfig {
   emailRecipients?: string[];
   /** Cross-source disagreement threshold, percent */
   sourceDisagreementThresholdPercent?: number;
+  /** SLA breach alerting: max breaches per window before alert fires */
+  slaBreachMaxPerWindow?: number;
+  /** SLA breach alerting: rolling window in seconds */
+  slaBreachWindowSeconds?: number;
+  /** SLA threshold in seconds (must match SLA_THRESHOLD_SECONDS in base.ts) */
+  slaThresholdSeconds?: number;
 }
 
 class AlertManager {
@@ -46,12 +55,16 @@ class AlertManager {
   private sourceFailureCount: Map<string, number> = new Map();
   private config: AlertConfig;
   private alertHistory: AlertEvent[] = [];
+  private slaBreachTimestamps: Map<string, number[]> = new Map();
   private static readonly DEFAULT_CONFIG: AlertConfig = {
     webhookRetries: 3,
     webhookRetryDelayMs: 1000,
     enableConsoleLog: true,
     enableFileLog: true,
     alertHistoryPath: path.resolve(__dirname, '../../data/alerts.jsonl'),
+    slaBreachMaxPerWindow: 10,
+    slaBreachWindowSeconds: 300,
+    slaThresholdSeconds: 5,
   };
 
   constructor(config: Partial<AlertConfig> = {}) {
@@ -132,6 +145,36 @@ class AlertManager {
       } else {
         this.sourceFailureCount.set(failureKey, 0);
       }
+    }
+  }
+
+  /**
+   * Records an SLA breach and fires an alert when the rolling-window rate
+   * exceeds the configured threshold.
+   */
+  async checkSlaBreach(source: string, asset: string, elapsedSeconds: number): Promise<void> {
+    const now = Math.floor(Date.now() / 1000);
+    const key = `${source}:${asset}`;
+    const timestamps = this.slaBreachTimestamps.get(key) || [];
+
+    const windowStart = now - (this.config.slaBreachWindowSeconds ?? 300);
+    const recent = timestamps.filter((t) => t >= windowStart);
+    recent.push(now);
+    this.slaBreachTimestamps.set(key, recent);
+
+    const thresholdSeconds = this.config.slaThresholdSeconds ?? 5;
+    if (recent.length > (this.config.slaBreachMaxPerWindow ?? 10)) {
+      await this.emitAlert({
+        timestamp: now,
+        asset,
+        type: 'sla_breach',
+        message: `SLA breach threshold exceeded for ${source}/${asset}: ${recent.length} breaches in ${this.config.slaBreachWindowSeconds ?? 300}s (max: ${this.config.slaBreachMaxPerWindow ?? 10})`,
+        source,
+        elapsedSeconds,
+        thresholdSeconds,
+      });
+
+      this.slaBreachTimestamps.set(key, []);
     }
   }
 
@@ -228,7 +271,7 @@ class AlertManager {
           payload: {
             summary: alert.message,
             source: 'price-oracle-aggregator',
-            severity: alert.type === 'source_down' ? 'critical' : 'warning',
+            severity: (alert.type === 'source_down' || alert.type === 'sla_breach') ? 'critical' : 'warning',
             custom_details: alert,
           },
         }),

--- a/services/aggregator/src/observability/health-server.ts
+++ b/services/aggregator/src/observability/health-server.ts
@@ -4,6 +4,7 @@ import { withCorrelation, correlationHeaders } from '../infrastructure/correlati
 import { SourceCBStatus } from '../price-aggregation/source-circuit-breaker';
 import { register } from './metrics';
 import { getDailyCounts } from '../infrastructure/cost-model';
+import { getUptimeHistory, getUptimeForPeriod, getLatestUptime } from '../persistence/uptime-history';
 
 interface HealthSnapshot {
   sourceHealth: Record<string, any>;
@@ -65,6 +66,50 @@ export class HealthServer {
           hasPrices,
           openCircuitBreakers: openCircuits.length,
         }));
+        return;
+      }
+
+      // ── Uptime history query endpoints ──────────────────────────────
+      const uptimeMatch = url.pathname.match(/^\/health\/uptime\/(\w+)$/);
+      if (uptimeMatch) {
+        const source = uptimeMatch[1];
+        const from = url.searchParams.get('from');
+        const to = url.searchParams.get('to');
+        const limit = parseInt(url.searchParams.get('limit') || '720', 10);
+        const window = url.searchParams.get('window');
+
+        if (window) {
+          const windowSeconds = parseInt(window, 10);
+          const stats = getUptimeForPeriod(source, windowSeconds);
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ source, ...stats }));
+          return;
+        }
+
+        const history = getUptimeHistory(
+          source,
+          from ? parseInt(from, 10) : undefined,
+          to ? parseInt(to, 10) : undefined,
+          limit,
+        );
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ source, history }));
+        return;
+      }
+
+      if (url.pathname === '/health/uptime') {
+        const snap = this.getSnapshot();
+        const uptimeSummary = Object.entries(snap.sourceHealth).map(([name, h]: [string, any]) => ({
+          source: name,
+          current: {
+            healthy: h.healthy,
+            uptimePercent: h.uptimePercent,
+            consecutiveFailures: h.consecutiveFailures,
+          },
+          latest: getLatestUptime(name),
+        }));
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ sources: uptimeSummary }));
         return;
       }
 

--- a/services/aggregator/src/observability/metrics.ts
+++ b/services/aggregator/src/observability/metrics.ts
@@ -85,4 +85,11 @@ export const oracleApiBudgetUtilization = new client.Gauge({
   registers: [register],
 });
 
+export const oracleSourceUptimePercent = new client.Gauge({
+  name: 'oracle_source_uptime_percent',
+  help: 'Current uptime percentage per oracle source (0–100)',
+  labelNames: ['source'],
+  registers: [register],
+});
+
 export { register };

--- a/services/aggregator/src/oracle-sources/base.ts
+++ b/services/aggregator/src/oracle-sources/base.ts
@@ -3,6 +3,7 @@ import BigNumber from 'bignumber.js';
 import { logger } from '../observability/logger';
 import { NormalizedPrice, OracleSourceName, SourceHealthStatus } from '../infrastructure/types';
 import { sourceCircuitBreaker } from '../price-aggregation/source-circuit-breaker';
+import { eventBus } from '../domain-events';
 import {
   oracleSourceLatency,
   oracleSourceRequestsTotal,
@@ -75,6 +76,16 @@ export abstract class BaseSource {
       oracleSourceRequestsTotal.inc({ source: this.name, status: 'success' });
       if (elapsed > SLA_THRESHOLD_SECONDS) {
         oracleSourceSlaBreaches.inc({ source: this.name });
+        eventBus.publish({
+          type: 'sla_breach',
+          payload: {
+            source: this.name,
+            asset,
+            elapsedSeconds: elapsed,
+            thresholdSeconds: SLA_THRESHOLD_SECONDS,
+          },
+          timestamp: Date.now(),
+        });
       }
 
       this.health.lastSuccess = Math.floor(Date.now() / 1000);

--- a/services/aggregator/src/persistence/history.ts
+++ b/services/aggregator/src/persistence/history.ts
@@ -13,7 +13,7 @@ export function ensureDataDir(): void {
 }
 
 /** Whether historical price files should be encrypted at rest (issue #41). */
-function historyEncryptionEnabled(): boolean {
+export function historyEncryptionEnabled(): boolean {
   return config.security.encryption.encryptHistory && isEncryptionConfigured();
 }
 

--- a/services/aggregator/src/persistence/uptime-history.ts
+++ b/services/aggregator/src/persistence/uptime-history.ts
@@ -1,0 +1,110 @@
+import fs from 'fs';
+import path from 'path';
+import { SourceHealthStatus } from '../infrastructure/types';
+import { config } from '../infrastructure/config';
+import { encrypt, decrypt, isEncrypted } from '../infrastructure/crypto';
+import { ensureDataDir, historyEncryptionEnabled } from './history';
+
+const DATA_DIR = path.resolve(__dirname, '../../data');
+const UPTIME_FILE = (source: string) => path.join(DATA_DIR, `uptime-${source.toLowerCase()}.json`);
+
+export interface UptimeSnapshot {
+  timestamp: number;
+  healthy: boolean;
+  uptimePercent: number;
+  totalRequests: number;
+  totalFailures: number;
+  consecutiveFailures: number;
+  lastSuccess: number | null;
+  lastFailure: number | null;
+}
+
+function uptimeEncryptionEnabled(): boolean {
+  return historyEncryptionEnabled();
+}
+
+function readUptimeFile(filePath: string): UptimeSnapshot[] {
+  if (!fs.existsSync(filePath)) return [];
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  if (!raw) return [];
+  const contents = isEncrypted(raw) ? decrypt(raw) : raw;
+  return JSON.parse(contents);
+}
+
+function writeUptimeFile(filePath: string, snapshots: UptimeSnapshot[]): void {
+  const serialized = JSON.stringify(snapshots);
+  const payload = uptimeEncryptionEnabled() ? encrypt(serialized) : serialized;
+  fs.writeFileSync(filePath, payload);
+}
+
+function pruneUptimeHistory(history: UptimeSnapshot[]): UptimeSnapshot[] {
+  const { maxEntries, retentionSeconds } = config.history;
+  let pruned = history;
+
+  if (retentionSeconds > 0) {
+    const cutoff = Math.floor(Date.now() / 1000) - retentionSeconds;
+    pruned = pruned.filter((h) => h.timestamp >= cutoff);
+  }
+
+  return maxEntries > 0 && pruned.length > maxEntries ? pruned.slice(-maxEntries) : pruned;
+}
+
+export function appendUptimeSnapshot(source: string, health: SourceHealthStatus): void {
+  ensureDataDir();
+  const filePath = UPTIME_FILE(source);
+  let history: UptimeSnapshot[] = [];
+  try {
+    history = readUptimeFile(filePath);
+  } catch { /* ignore corrupt data */ }
+
+  const snapshot: UptimeSnapshot = {
+    timestamp: Math.floor(Date.now() / 1000),
+    healthy: health.healthy,
+    uptimePercent: health.uptimePercent,
+    totalRequests: health.totalRequests,
+    totalFailures: health.totalFailures,
+    consecutiveFailures: health.consecutiveFailures,
+    lastSuccess: health.lastSuccess,
+    lastFailure: health.lastFailure,
+  };
+
+  history.push(snapshot);
+  writeUptimeFile(filePath, pruneUptimeHistory(history));
+}
+
+export function getUptimeHistory(
+  source: string,
+  from?: number,
+  to?: number,
+  limit = 720,
+): UptimeSnapshot[] {
+  const filePath = UPTIME_FILE(source);
+  try {
+    let history = readUptimeFile(filePath);
+    if (from) history = history.filter((h) => h.timestamp >= from);
+    if (to) history = history.filter((h) => h.timestamp <= to);
+    return history.slice(-limit);
+  } catch {
+    return [];
+  }
+}
+
+export function getLatestUptime(source: string): UptimeSnapshot | null {
+  const history = getUptimeHistory(source, undefined, undefined, 1);
+  return history.length > 0 ? history[0] : null;
+}
+
+export function getUptimeForPeriod(
+  source: string,
+  windowSeconds: number,
+): { averageUptimePercent: number; breachCount: number } {
+  const cutoff = Math.floor(Date.now() / 1000) - windowSeconds;
+  const history = getUptimeHistory(source, cutoff);
+  if (history.length === 0) return { averageUptimePercent: 100, breachCount: 0 };
+
+  const total = history.reduce((sum, h) => sum + h.uptimePercent, 0);
+  const averageUptimePercent = Math.round((total / history.length) * 100) / 100;
+  const breachCount = history.filter((h) => h.healthy === false).length;
+
+  return { averageUptimePercent, breachCount };
+}


### PR DESCRIPTION
Closes #263
Closes #264
Closes #265
Closes #266

…ting

- Create uptime-history persistence module that snapshots SourceHealthStatus to JSON files (with encryption support), reusing helpers from history.ts
- Add Prometheus Gauge oracleSourceUptimePercent updated every poll cycle
- Add /health/uptime/:source endpoint for historical uptime queries with window-based aggregate stats and time-range filtering
- Add SlaBreachEvent to domain events and publish it from BaseSource when elapsed time exceeds the SLA threshold
- Add checkSlaBreach() to AlertManager with configurable rolling-window rate limiting (slaBreachMaxPerWindow, slaBreachWindowSeconds, slaThresholdSeconds) - fires critical alerts via Slack/PagerDuty/email
- Add PrometheusRule in k8s/base with warning and critical SLA breach rate alerts plus uptime degradation alert
- Subscribe to sla_breach events in main() to route to AlertManager
- Make historyEncryptionEnabled() exported for reuse