### PR TITLE
test: add unit tests for oracle sources, database client, pool, and health monitor

### DIFF
--- a/api/tests/database.test.ts
+++ b/api/tests/database.test.ts
@@ -1,0 +1,542 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Pool } from 'pg';
+import { config } from '../src/infrastructure/config';
+import { DatabaseClient, setDb, getDb, isDbAvailable } from '../src/infrastructure/database';
+
+const mockPoolQuery = vi.fn();
+const mockPoolConnect = vi.fn();
+const mockPoolEnd = vi.fn();
+const mockPoolOn = vi.fn();
+
+const mockPoolInstance = {
+  query: mockPoolQuery,
+  connect: mockPoolConnect,
+  end: mockPoolEnd,
+  on: mockPoolOn,
+  totalCount: 5,
+  idleCount: 2,
+  waitingCount: 0,
+};
+
+vi.mock('pg', () => ({
+  Pool: vi.fn(function MockPool() { return mockPoolInstance; }),
+  default: { Pool: vi.fn(function MockPool() { return mockPoolInstance; }) },
+}));
+
+vi.mock('../src/infrastructure/config', () => {
+  const defaults = {
+    poolMin: 2,
+    poolMax: 10,
+    idleTimeoutMs: 30000,
+    connectionTimeoutMs: 5000,
+    statementTimeoutMs: 10000,
+  };
+  return {
+    config: {
+      db: {
+        ...defaults,
+        retry: { maxRetries: 3, baseDelayMs: 100, maxDelayMs: 1000 },
+        circuitBreaker: {
+          enabled: true,
+          failureThreshold: 3,
+          successThreshold: 2,
+          openMs: 5000,
+        },
+        replica: {
+          urls: [],
+          maxLagMs: 0,
+          healthCheckIntervalMs: 15000,
+        },
+      },
+      useTimescale: false,
+    },
+  };
+});
+
+vi.mock('../src/observability/metrics', () => {
+  const mockGauge = { set: vi.fn(), inc: vi.fn() };
+  const mockCounter = { inc: vi.fn() };
+  return {
+    dbReplicaHealthy: mockGauge,
+    dbReplicaLagSeconds: mockGauge,
+    dbPoolTotalConnections: mockGauge,
+    dbPoolIdleConnections: mockGauge,
+    dbPoolWaitingCount: mockGauge,
+    dbPoolMaxConnections: mockGauge,
+    dbQueryDuration: { startTimer: vi.fn(() => () => 0) },
+    dbQueryErrorsTotal: mockCounter,
+    dbRetriesTotal: mockCounter,
+    dbCircuitBreakerState: mockGauge,
+    register: { registerMetric: vi.fn() },
+  };
+});
+
+const logger = {
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+} as any;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPoolQuery.mockReset();
+  mockPoolConnect.mockReset();
+  mockPoolEnd.mockReset();
+  mockPoolOn.mockReset();
+  mockPoolInstance.totalCount = 5;
+  mockPoolInstance.idleCount = 2;
+  mockPoolInstance.waitingCount = 0;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function createClient(replicaUrls: string[] = []): DatabaseClient {
+  const originalUrls = config.db.replica.urls;
+  config.db.replica.urls = replicaUrls;
+  const client = new DatabaseClient('postgres://localhost:5432/test', logger);
+  config.db.replica.urls = originalUrls;
+  return client;
+}
+
+describe('DatabaseClient', () => {
+  it('creates a primary pool on construction', () => {
+    const client = new DatabaseClient('postgres://localhost:5432/test', logger);
+
+    expect(Pool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectionString: 'postgres://localhost:5432/test',
+        max: 10,
+        min: 2,
+      }),
+    );
+    expect(client.isInitialized()).toBe(false);
+  });
+
+  it('creates replica pools when configured', () => {
+    createClient(['postgres://replica-1:5432/test', 'postgres://replica-2:5432/test']);
+
+    expect(Pool).toHaveBeenCalledTimes(3);
+  });
+
+  it('logs replica count when replicas are configured', () => {
+    createClient(['postgres://replica-1:5432/test']);
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('1 read replica'),
+    );
+  });
+
+  it('creates schema and sets initialized flag on successful init', async () => {
+    const mockClient = {
+      query: vi.fn().mockResolvedValue({}),
+      release: vi.fn(),
+    };
+    mockPoolConnect.mockResolvedValue(mockClient);
+
+    const client = new DatabaseClient('postgres://localhost:5432/test', logger);
+    await client.initialize();
+
+    expect(client.isInitialized()).toBe(true);
+    expect(mockClient.query).toHaveBeenCalledWith(
+      expect.stringContaining('CREATE TABLE IF NOT EXISTS price_history'),
+    );
+    expect(mockClient.release).toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith('PostgreSQL database initialized');
+  });
+
+  it('throws and does not set initialized on schema creation failure', async () => {
+    const mockClient = {
+      query: vi.fn().mockRejectedValue(new Error('permission denied')),
+      release: vi.fn(),
+    };
+    mockPoolConnect.mockResolvedValue(mockClient);
+
+    const client = new DatabaseClient('postgres://localhost:5432/test', logger);
+    await expect(client.initialize()).rejects.toThrow('permission denied');
+
+    expect(client.isInitialized()).toBe(false);
+    expect(mockClient.release).toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      'Failed to initialize database',
+      expect.any(Error),
+    );
+  });
+
+  it('tries to enable TimescaleDB when configured', async () => {
+    config.useTimescale = true;
+
+    const mockClient = {
+      query: vi.fn().mockResolvedValue({}),
+      release: vi.fn(),
+    };
+    mockPoolConnect.mockResolvedValue(mockClient);
+
+    const client = new DatabaseClient('postgres://localhost:5432/test', logger);
+    await client.initialize();
+
+    expect(client.isTimescaleEnabled()).toBe(true);
+    expect(mockClient.query).toHaveBeenCalledWith(
+      expect.stringContaining('CREATE EXTENSION IF NOT EXISTS timescaledb'),
+    );
+
+    config.useTimescale = false;
+  });
+
+  it('falls back gracefully when TimescaleDB is unavailable', async () => {
+    config.useTimescale = true;
+
+    const mockClient = {
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({})
+        .mockRejectedValueOnce(new Error('extension not available')),
+      release: vi.fn(),
+    };
+    mockPoolConnect.mockResolvedValue(mockClient);
+
+    const client = new DatabaseClient('postgres://localhost:5432/test', logger);
+    await client.initialize();
+
+    expect(client.isInitialized()).toBe(true);
+    expect(client.isTimescaleEnabled()).toBe(false);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('TimescaleDB not available'),
+      expect.any(Error),
+    );
+
+    config.useTimescale = false;
+  });
+
+  it('executes a write query against the primary', async () => {
+    mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+
+    const client = new DatabaseClient('postgres://localhost:5432/test', logger);
+    const result = await client.query('INSERT INTO price_history VALUES ($1, $2)', ['XLM', '100']);
+
+    expect(result).toEqual({ rows: [], rowCount: 0 });
+    expect(mockPoolQuery).toHaveBeenCalledWith(
+      'INSERT INTO price_history VALUES ($1, $2)',
+      ['XLM', '100'],
+    );
+  });
+
+  it('readQuery reads against primary when no replicas', async () => {
+    mockPoolQuery.mockResolvedValue({ rows: [{ id: 1 }], rowCount: 1 });
+
+    const client = new DatabaseClient('postgres://localhost:5432/test', logger);
+    const result = await client.readQuery('SELECT * FROM price_history LIMIT 10');
+
+    expect(result.rows).toEqual([{ id: 1 }]);
+    expect(mockPoolQuery).toHaveBeenCalledWith(
+      'SELECT * FROM price_history LIMIT 10',
+      undefined,
+    );
+  });
+
+  it('readQuery falls back to primary when replica query fails', async () => {
+    const client = createClient(['postgres://replica-1:5432/test']);
+
+    mockPoolQuery
+      .mockRejectedValueOnce(new Error('replica down'))
+      .mockResolvedValueOnce({ rows: [{ id: 1 }], rowCount: 1 });
+
+    const result = await client.readQuery('SELECT 1');
+
+    expect(result.rows).toEqual([{ id: 1 }]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('falling back to primary'),
+      expect.any(Error),
+    );
+  });
+
+  it('getHistoricalPrices throws when not initialized', async () => {
+    const client = new DatabaseClient('postgres://localhost:5432/test', logger);
+    await expect(client.getHistoricalPrices('XLM')).rejects.toThrow(
+      'Database not initialized',
+    );
+  });
+
+  it('getHistoricalPrices returns rows for a given asset', async () => {
+    const mockClient = {
+      query: vi.fn().mockResolvedValue({}),
+      release: vi.fn(),
+    };
+    mockPoolConnect.mockResolvedValue(mockClient);
+    mockPoolQuery.mockResolvedValue({
+      rows: [
+        {
+          id: 1,
+          asset: 'XLM',
+          price: '100',
+          decimals: 7,
+          source: 'chainlink',
+          timestamp: 1719000000,
+          created_at: new Date('2024-06-21'),
+        },
+      ],
+      rowCount: 1,
+    });
+
+    const client = new DatabaseClient('postgres://localhost:5432/test', logger);
+    await client.initialize();
+
+    const prices = await client.getHistoricalPrices('XLM');
+
+    expect(prices).toHaveLength(1);
+    expect(prices[0].asset).toBe('XLM');
+    expect(prices[0].price).toBe('100');
+    expect(prices[0].source).toBe('chainlink');
+  });
+
+  it('getHistoricalPrices supports time range filters', async () => {
+    const mockClient = {
+      query: vi.fn().mockResolvedValue({}),
+      release: vi.fn(),
+    };
+    mockPoolConnect.mockResolvedValue(mockClient);
+    mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+
+    const client = new DatabaseClient('postgres://localhost:5432/test', logger);
+    await client.initialize();
+
+    await client.getHistoricalPrices('XLM', 1719000000, 1720000000, 50);
+
+    expect(mockPoolQuery).toHaveBeenCalledWith(
+      expect.stringContaining('timestamp >='),
+      expect.arrayContaining(['XLM', 1719000000, 1720000000, 50]),
+    );
+  });
+
+  it('getHistoricalPrices supports only from filter', async () => {
+    const mockClient = {
+      query: vi.fn().mockResolvedValue({}),
+      release: vi.fn(),
+    };
+    mockPoolConnect.mockResolvedValue(mockClient);
+    mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+
+    const client = new DatabaseClient('postgres://localhost:5432/test', logger);
+    await client.initialize();
+
+    await client.getHistoricalPrices('XLM', 1719000000);
+
+    expect(mockPoolQuery).toHaveBeenCalledWith(
+      expect.stringContaining('timestamp >='),
+      expect.arrayContaining(['XLM', 1719000000, 100]),
+    );
+    expect(mockPoolQuery).not.toHaveBeenCalledWith(
+      expect.stringContaining('timestamp <='),
+      expect.anything(),
+    );
+  });
+
+  it('getHistoricalPrices throws on query error', async () => {
+    const mockClient = {
+      query: vi.fn().mockResolvedValue({}),
+      release: vi.fn(),
+    };
+    mockPoolConnect.mockResolvedValue(mockClient);
+    mockPoolQuery.mockRejectedValue(new Error('table does not exist'));
+
+    const client = new DatabaseClient('postgres://localhost:5432/test', logger);
+    await client.initialize();
+
+    await expect(client.getHistoricalPrices('XLM')).rejects.toThrow('table does not exist');
+    expect(logger.error).toHaveBeenCalledWith(
+      'Failed to query price history',
+      expect.any(Error),
+    );
+  });
+
+  it('getAllLatestPrices throws when not initialized', async () => {
+    const client = new DatabaseClient('postgres://localhost:5432/test', logger);
+    await expect(client.getAllLatestPrices()).rejects.toThrow(
+      'Database not initialized',
+    );
+  });
+
+  it('getAllLatestPrices returns distinct assets', async () => {
+    const mockClient = {
+      query: vi.fn().mockResolvedValue({}),
+      release: vi.fn(),
+    };
+    mockPoolConnect.mockResolvedValue(mockClient);
+    mockPoolQuery.mockResolvedValue({
+      rows: [
+        {
+          id: 1,
+          asset: 'XLM',
+          price: '100',
+          decimals: 7,
+          source: 'chainlink',
+          timestamp: 1719000000,
+          created_at: new Date(),
+        },
+        {
+          id: 2,
+          asset: 'BTC',
+          price: '65000',
+          decimals: 8,
+          source: 'redstone',
+          timestamp: 1719000000,
+          created_at: new Date(),
+        },
+      ],
+      rowCount: 2,
+    });
+
+    const client = new DatabaseClient('postgres://localhost:5432/test', logger);
+    await client.initialize();
+
+    const prices = await client.getAllLatestPrices();
+
+    expect(prices).toHaveLength(2);
+    expect(prices[0].asset).toBe('XLM');
+    expect(prices[1].asset).toBe('BTC');
+  });
+
+  it('getAllLatestPrices throws on query error', async () => {
+    const mockClient = {
+      query: vi.fn().mockResolvedValue({}),
+      release: vi.fn(),
+    };
+    mockPoolConnect.mockResolvedValue(mockClient);
+    mockPoolQuery.mockRejectedValue(new Error('connection lost'));
+
+    const client = new DatabaseClient('postgres://localhost:5432/test', logger);
+    await client.initialize();
+
+    await expect(client.getAllLatestPrices()).rejects.toThrow('connection lost');
+    expect(logger.error).toHaveBeenCalledWith(
+      'Failed to fetch all latest prices',
+      expect.any(Error),
+    );
+  });
+
+  it('getLatestPrice throws when not initialized', async () => {
+    const client = new DatabaseClient('postgres://localhost:5432/test', logger);
+    await expect(client.getLatestPrice('XLM')).rejects.toThrow(
+      'Database not initialized',
+    );
+  });
+
+  it('getLatestPrice returns the row for the given asset', async () => {
+    const mockClient = {
+      query: vi.fn().mockResolvedValue({}),
+      release: vi.fn(),
+    };
+    mockPoolConnect.mockResolvedValue(mockClient);
+    mockPoolQuery.mockResolvedValue({
+      rows: [
+        {
+          id: 1,
+          asset: 'XLM',
+          price: '100',
+          decimals: 7,
+          source: 'chainlink',
+          timestamp: 1719000000,
+          created_at: new Date(),
+        },
+      ],
+      rowCount: 1,
+    });
+
+    const client = new DatabaseClient('postgres://localhost:5432/test', logger);
+    await client.initialize();
+
+    const price = await client.getLatestPrice('XLM');
+
+    expect(price).not.toBeNull();
+    expect(price!.asset).toBe('XLM');
+    expect(mockPoolQuery).toHaveBeenCalledWith(
+      expect.stringContaining('ORDER BY timestamp DESC LIMIT 1'),
+      ['XLM'],
+    );
+  });
+
+  it('getLatestPrice returns null when no rows found', async () => {
+    const mockClient = {
+      query: vi.fn().mockResolvedValue({}),
+      release: vi.fn(),
+    };
+    mockPoolConnect.mockResolvedValue(mockClient);
+    mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+
+    const client = new DatabaseClient('postgres://localhost:5432/test', logger);
+    await client.initialize();
+
+    const price = await client.getLatestPrice('UNKNOWN');
+
+    expect(price).toBeNull();
+  });
+
+  it('getLatestPrice throws on query error', async () => {
+    const mockClient = {
+      query: vi.fn().mockResolvedValue({}),
+      release: vi.fn(),
+    };
+    mockPoolConnect.mockResolvedValue(mockClient);
+    mockPoolQuery.mockRejectedValue(new Error('query timeout'));
+
+    const client = new DatabaseClient('postgres://localhost:5432/test', logger);
+    await client.initialize();
+
+    await expect(client.getLatestPrice('XLM')).rejects.toThrow('query timeout');
+    expect(logger.error).toHaveBeenCalledWith(
+      'Failed to fetch latest price',
+      expect.any(Error),
+    );
+  });
+
+  it('getPoolStats returns primary and replica stats', () => {
+    const client = new DatabaseClient('postgres://localhost:5432/test', logger);
+    const stats = client.getPoolStats();
+
+    expect(stats.primary).toBeDefined();
+    expect(stats.primary.name).toBe('primary');
+    expect(stats.replicas).toEqual([]);
+  });
+
+  it('getPoolStats includes replica stats when replicas are configured', () => {
+    const client = createClient(['postgres://replica-1:5432/test']);
+    const stats = client.getPoolStats();
+
+    expect(stats.replicas).toHaveLength(1);
+    expect(stats.replicas[0].name).toBe('replica-0');
+  });
+
+  it('disconnect closes all pools', async () => {
+    const client = createClient(['postgres://replica-1:5432/test']);
+
+    await client.disconnect();
+
+    expect(mockPoolEnd).toHaveBeenCalledTimes(2);
+    expect(logger.info).toHaveBeenCalledWith('Database connection pools closed');
+  });
+
+  it('setDb / getDb / isDbAvailable work correctly', async () => {
+    expect(isDbAvailable()).toBe(false);
+    await expect(getDb()).rejects.toThrow('Database not initialized');
+
+    const client = new DatabaseClient('postgres://localhost:5432/test', logger);
+    setDb(client);
+
+    expect(isDbAvailable()).toBe(true);
+    await expect(getDb()).resolves.toBe(client);
+  });
+
+  it('disconnect clears timers after init', async () => {
+    const mockClient = {
+      query: vi.fn().mockResolvedValue({}),
+      release: vi.fn(),
+    };
+    mockPoolConnect.mockResolvedValue(mockClient);
+
+    const client = new DatabaseClient('postgres://localhost:5432/test', logger);
+    await client.initialize();
+
+    await client.disconnect();
+  });
+});

--- a/api/tests/db-health-monitor.test.ts
+++ b/api/tests/db-health-monitor.test.ts
@@ -1,0 +1,465 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { DbHealthMonitor } from '../src/infrastructure/db-health-monitor';
+
+vi.mock('prom-client', () => ({
+  default: {
+    Counter: vi.fn(function MockCounter() {
+      this.inc = vi.fn();
+      return this;
+    }),
+    Gauge: vi.fn(function MockGauge() {
+      this.set = vi.fn();
+      return this;
+    }),
+    Registry: vi.fn(function MockRegistry() {
+      this.registerMetric = vi.fn();
+      this.metrics = vi.fn(() => Promise.resolve(''));
+      this.contentType = 'text/plain';
+      return this;
+    }),
+    collectDefaultMetrics: vi.fn(),
+  },
+  Counter: vi.fn(function MockCounter() {
+    this.inc = vi.fn();
+    return this;
+  }),
+  Gauge: vi.fn(function MockGauge() {
+    this.set = vi.fn();
+    return this;
+  }),
+  Registry: vi.fn(function MockRegistry() {
+    this.registerMetric = vi.fn();
+    this.metrics = vi.fn(() => Promise.resolve(''));
+    this.contentType = 'text/plain';
+    return this;
+  }),
+}));
+
+vi.mock('../src/observability/metrics', () => ({
+  register: { registerMetric: vi.fn() },
+}));
+
+const logger = {
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+} as any;
+
+function mockDbClient(overrides: Record<string, any> = {}) {
+  const stats = {
+    primary: {
+      name: 'primary',
+      total: 5,
+      idle: 2,
+      waiting: 0,
+      max: 10,
+      circuitState: 'closed',
+    },
+    replicas: [
+      {
+        name: 'replica-0',
+        total: 5,
+        idle: 3,
+        waiting: 0,
+        max: 10,
+        circuitState: 'closed',
+      },
+    ],
+  };
+
+  return {
+    getPoolStats: vi.fn(() => ({ ...stats, ...overrides.stats })),
+    readQuery: vi.fn(),
+    ...overrides,
+  } as any;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('DbHealthMonitor', () => {
+  it('creates a monitor with default configuration', () => {
+    const db = mockDbClient();
+    const monitor = new DbHealthMonitor(db, logger);
+    expect(monitor).toBeDefined();
+  });
+
+  it('creates a monitor with custom configuration', () => {
+    const db = mockDbClient();
+    const monitor = new DbHealthMonitor(db, logger, {
+      checkIntervalMs: 5000,
+      connectionExhaustionThreshold: 0.5,
+      slowQueryThresholdMs: 2000,
+      replicationLagAlertMs: 15000,
+    });
+    expect(monitor).toBeDefined();
+  });
+
+  it('start begins periodic health checks', () => {
+    const db = mockDbClient();
+    db.readQuery.mockResolvedValue({ rows: [{ '?column?': 1 }] });
+    const monitor = new DbHealthMonitor(db, logger);
+
+    monitor.start();
+
+    expect(db.getPoolStats).toHaveBeenCalledTimes(1);
+  });
+
+  it('stop clears the interval timer', () => {
+    const db = mockDbClient();
+    const monitor = new DbHealthMonitor(db, logger);
+
+    monitor.start();
+    expect(() => monitor.stop()).not.toThrow();
+  });
+
+  it('double stop does not throw', () => {
+    const db = mockDbClient();
+    const monitor = new DbHealthMonitor(db, logger);
+
+    monitor.start();
+    monitor.stop();
+    expect(() => monitor.stop()).not.toThrow();
+  });
+
+  it('reports healthy when no issues found', async () => {
+    const db = mockDbClient();
+    db.readQuery.mockResolvedValue({ rows: [{ '?column?': 1 }] });
+
+    const monitor = new DbHealthMonitor(db, logger);
+    const report = await monitor.runCheck();
+
+    expect(report.status).toBe('healthy');
+    expect(report.issues).toHaveLength(0);
+    expect(report.probeLatencyMs).toBeGreaterThanOrEqual(0);
+    expect(report.checkedAt).toBeGreaterThan(0);
+  });
+
+  it('reports degraded when connection exhaustion threshold is exceeded', async () => {
+    const db = mockDbClient({
+      stats: {
+        primary: {
+          name: 'primary',
+          total: 10,
+          idle: 0,
+          waiting: 9,
+          max: 10,
+          circuitState: 'closed',
+        },
+        replicas: [],
+      },
+    });
+    db.readQuery.mockResolvedValue({ rows: [{ '?column?': 1 }] });
+
+    const monitor = new DbHealthMonitor(db, logger, {
+      connectionExhaustionThreshold: 0.8,
+    });
+    const report = await monitor.runCheck();
+
+    expect(report.status).toBe('degraded');
+    expect(report.issues.some((i: string) => i.includes('connection exhaustion'))).toBe(true);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('connection exhaustion'),
+    );
+  });
+
+  it('does not alert when exhaustion is below threshold', async () => {
+    const db = mockDbClient({
+      stats: {
+        primary: {
+          name: 'primary',
+          total: 10,
+          idle: 3,
+          waiting: 5,
+          max: 10,
+          circuitState: 'closed',
+        },
+        replicas: [],
+      },
+    });
+    db.readQuery.mockResolvedValue({ rows: [{ '?column?': 1 }] });
+
+    const monitor = new DbHealthMonitor(db, logger, {
+      connectionExhaustionThreshold: 0.8,
+    });
+    const report = await monitor.runCheck();
+
+    expect(report.status).toBe('healthy');
+    expect(report.issues.some((i: string) => i.includes('connection exhaustion'))).toBe(false);
+  });
+
+  it('reports critical when circuit breaker is open', async () => {
+    const db = mockDbClient({
+      stats: {
+        primary: {
+          name: 'primary',
+          total: 5,
+          idle: 2,
+          waiting: 0,
+          max: 10,
+          circuitState: 'open',
+        },
+        replicas: [],
+      },
+    });
+    db.readQuery.mockResolvedValue({ rows: [{ '?column?': 1 }] });
+
+    const monitor = new DbHealthMonitor(db, logger);
+    const report = await monitor.runCheck();
+
+    expect(report.status).toBe('critical');
+    expect(report.issues.some((i: string) => i.includes('circuit breaker'))).toBe(true);
+  });
+
+  it('reports circuit open on replica pool', async () => {
+    const db = mockDbClient({
+      stats: {
+        primary: {
+          name: 'primary',
+          total: 5,
+          idle: 2,
+          waiting: 0,
+          max: 10,
+          circuitState: 'closed',
+        },
+        replicas: [
+          {
+            name: 'replica-0',
+            total: 5,
+            idle: 3,
+            waiting: 0,
+            max: 10,
+            circuitState: 'open',
+          },
+        ],
+      },
+    });
+    db.readQuery.mockResolvedValue({ rows: [{ '?column?': 1 }] });
+
+    const monitor = new DbHealthMonitor(db, logger);
+    const report = await monitor.runCheck();
+
+    expect(report.status).toBe('critical');
+    expect(report.issues.some((i: string) => i.includes('circuit breaker'))).toBe(true);
+  });
+
+  it('reports degraded when probe latency exceeds the threshold', async () => {
+    const db = mockDbClient();
+    // Simulate a slow query
+    db.readQuery.mockImplementation(
+      () => new Promise((resolve) => setTimeout(() => resolve({ rows: [{ '?column?': 1 }] }), 50)),
+    );
+
+    const monitor = new DbHealthMonitor(db, logger, {
+      slowQueryThresholdMs: 25,
+    });
+    const reportPromise = monitor.runCheck();
+
+    await vi.advanceTimersByTimeAsync(100);
+    const report = await reportPromise;
+
+    expect(report.status).toBe('degraded');
+    expect(report.issues.some((i: string) => i.includes('probe latency'))).toBe(true);
+  });
+
+  it('does not alert when probe latency is within threshold', async () => {
+    const db = mockDbClient();
+    db.readQuery.mockResolvedValue({ rows: [{ '?column?': 1 }] });
+
+    const monitor = new DbHealthMonitor(db, logger, {
+      slowQueryThresholdMs: 5000,
+    });
+    const report = await monitor.runCheck();
+
+    expect(report.status).toBe('healthy');
+    expect(report.issues.some((i: string) => i.includes('probe latency'))).toBe(false);
+  });
+
+  it('reports critical when the liveness probe fails', async () => {
+    const db = mockDbClient();
+    db.readQuery.mockRejectedValue(new Error('connection refused'));
+
+    const monitor = new DbHealthMonitor(db, logger);
+    const report = await monitor.runCheck();
+
+    expect(report.status).toBe('critical');
+    expect(report.issues.some((i: string) => i.includes('liveness probe failed'))).toBe(true);
+    expect(report.probeLatencyMs).toBe(-1);
+  });
+
+  it('reports degraded when replication lag exceeds threshold', async () => {
+    const db = mockDbClient({
+      stats: {
+        primary: {
+          name: 'primary',
+          total: 5,
+          idle: 2,
+          waiting: 0,
+          max: 10,
+          circuitState: 'closed',
+        },
+        replicas: [
+          {
+            name: 'replica-0',
+            total: 5,
+            idle: 3,
+            waiting: 0,
+            max: 10,
+            circuitState: 'closed',
+          },
+        ],
+      },
+    });
+    db.readQuery
+      .mockResolvedValueOnce({ rows: [{ '?column?': 1 }] })
+      .mockResolvedValueOnce({ rows: [{ lag: '45' }] });
+
+    const monitor = new DbHealthMonitor(db, logger, {
+      replicationLagAlertMs: 30000,
+    });
+    const report = await monitor.runCheck();
+
+    expect(report.status).toBe('degraded');
+    expect(report.issues.some((i: string) => i.includes('Replication lag'))).toBe(true);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Replication lag'),
+    );
+  });
+
+  it('does not alert when replication lag is within threshold', async () => {
+    const db = mockDbClient();
+    db.readQuery
+      .mockResolvedValueOnce({ rows: [{ '?column?': 1 }] })
+      .mockResolvedValueOnce({ rows: [{ lag: '5' }] });
+
+    const monitor = new DbHealthMonitor(db, logger, {
+      replicationLagAlertMs: 60000,
+    });
+    const report = await monitor.runCheck();
+
+    expect(report.status).toBe('healthy');
+    expect(report.issues.some((i: string) => i.includes('Replication lag'))).toBe(false);
+  });
+
+  it('handles replication lag query failure gracefully', async () => {
+    const db = mockDbClient();
+    db.readQuery
+      .mockResolvedValueOnce({ rows: [{ '?column?': 1 }] })
+      .mockRejectedValueOnce(new Error('replica unavailable'));
+
+    const monitor = new DbHealthMonitor(db, logger);
+    const report = await monitor.runCheck();
+
+    expect(report.issues.some((i: string) => i.includes('Replication lag'))).toBe(false);
+  });
+
+  it('reports critical when both circuit open and probe fail', async () => {
+    const db = mockDbClient({
+      stats: {
+        primary: {
+          name: 'primary',
+          total: 5,
+          idle: 2,
+          waiting: 0,
+          max: 10,
+          circuitState: 'open',
+        },
+        replicas: [],
+      },
+    });
+    db.readQuery.mockRejectedValue(new Error('connection refused'));
+
+    const monitor = new DbHealthMonitor(db, logger);
+    const report = await monitor.runCheck();
+
+    expect(report.status).toBe('critical');
+    expect(report.issues.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('reports degraded when exhaustion and lag are both issues', async () => {
+    const db = mockDbClient({
+      stats: {
+        primary: {
+          name: 'primary',
+          total: 10,
+          idle: 0,
+          waiting: 9,
+          max: 10,
+          circuitState: 'closed',
+        },
+        replicas: [
+          {
+            name: 'replica-0',
+            total: 5,
+            idle: 3,
+            waiting: 0,
+            max: 10,
+            circuitState: 'closed',
+          },
+        ],
+      },
+    });
+    db.readQuery
+      .mockResolvedValueOnce({ rows: [{ '?column?': 1 }] })
+      .mockResolvedValueOnce({ rows: [{ lag: '60' }] });
+
+    const monitor = new DbHealthMonitor(db, logger, {
+      connectionExhaustionThreshold: 0.8,
+      replicationLagAlertMs: 30000,
+    });
+    const report = await monitor.runCheck();
+
+    expect(report.status).toBe('degraded');
+    expect(report.issues.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('getLastReport returns undefined before any check', () => {
+    const db = mockDbClient();
+    const monitor = new DbHealthMonitor(db, logger);
+
+    expect(monitor.getLastReport()).toBeUndefined();
+  });
+
+  it('getLastReport returns the most recent report after a check', async () => {
+    const db = mockDbClient();
+    db.readQuery.mockResolvedValue({ rows: [{ '?column?': 1 }] });
+
+    const monitor = new DbHealthMonitor(db, logger);
+    await monitor.runCheck();
+
+    const report = monitor.getLastReport();
+    expect(report).toBeDefined();
+    expect(report!.status).toBe('healthy');
+  });
+
+  it('handles pool with max=0 without division by zero', async () => {
+    const db = mockDbClient({
+      stats: {
+        primary: {
+          name: 'primary',
+          total: 0,
+          idle: 0,
+          waiting: 0,
+          max: 0,
+          circuitState: 'closed',
+        },
+        replicas: [],
+      },
+    });
+    db.readQuery.mockResolvedValue({ rows: [{ '?column?': 1 }] });
+
+    const monitor = new DbHealthMonitor(db, logger);
+    const report = await monitor.runCheck();
+
+    expect(report.status).toBe('healthy');
+    expect(report.issues).toHaveLength(0);
+  });
+});

--- a/api/tests/db-pool.test.ts
+++ b/api/tests/db-pool.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Pool } from 'pg';
+import { ManagedPool, ManagedPoolOptions } from '../src/infrastructure/db-pool';
+
+const mockQuery = vi.fn();
+const mockConnect = vi.fn();
+const mockEnd = vi.fn();
+const mockOn = vi.fn();
+
+const mockPoolInstance = {
+  query: mockQuery,
+  connect: mockConnect,
+  end: mockEnd,
+  on: mockOn,
+  totalCount: 5,
+  idleCount: 2,
+  waitingCount: 0,
+};
+
+vi.mock('pg', () => ({
+  Pool: vi.fn(function MockPool() { return mockPoolInstance; }),
+  default: { Pool: vi.fn(function MockPool() { return mockPoolInstance; }) },
+}));
+
+vi.mock('../src/observability/metrics', () => {
+  const mockGauge = { set: vi.fn(), inc: vi.fn() };
+  const mockCounter = { inc: vi.fn() };
+  return {
+    dbPoolTotalConnections: mockGauge,
+    dbPoolIdleConnections: mockGauge,
+    dbPoolWaitingCount: mockGauge,
+    dbPoolMaxConnections: mockGauge,
+    dbQueryDuration: { startTimer: vi.fn(() => () => 0) },
+    dbQueryErrorsTotal: mockCounter,
+    dbRetriesTotal: mockCounter,
+    dbCircuitBreakerState: mockGauge,
+  };
+});
+
+const defaultOpts: ManagedPoolOptions = {
+  name: 'primary',
+  connectionString: 'postgres://localhost:5432/test',
+  poolMin: 2,
+  poolMax: 10,
+  idleTimeoutMs: 30000,
+  connectionTimeoutMs: 5000,
+  statementTimeoutMs: 10000,
+  retry: { maxRetries: 3, baseDelayMs: 100, maxDelayMs: 1000 },
+  circuitBreaker: {
+    enabled: true,
+    failureThreshold: 3,
+    successThreshold: 2,
+    openMs: 5000,
+  },
+};
+
+const logger = {
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+} as any;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockQuery.mockReset();
+  mockConnect.mockReset();
+  mockEnd.mockReset();
+  mockOn.mockReset();
+  mockPoolInstance.totalCount = 5;
+  mockPoolInstance.idleCount = 2;
+  mockPoolInstance.waitingCount = 0;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ManagedPool', () => {
+  it('creates a pool with the given options', () => {
+    new ManagedPool(defaultOpts, logger);
+
+    expect(Pool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectionString: 'postgres://localhost:5432/test',
+        min: 2,
+        max: 10,
+        idleTimeoutMillis: 30000,
+        connectionTimeoutMillis: 5000,
+        statement_timeout: 10000,
+      }),
+    );
+  });
+
+  it('stores the pool name', () => {
+    const pool = new ManagedPool(defaultOpts, logger);
+    expect(pool.name).toBe('primary');
+  });
+
+  it('registers an error handler on the pool', () => {
+    new ManagedPool(defaultOpts, logger);
+    expect(mockOn).toHaveBeenCalledWith('error', expect.any(Function));
+  });
+
+  it('executes a query successfully', async () => {
+    mockQuery.mockResolvedValue({ rows: [{ id: 1 }], rowCount: 1 });
+    const pool = new ManagedPool(defaultOpts, logger);
+
+    const result = await pool.query('SELECT 1');
+
+    expect(result).toEqual({ rows: [{ id: 1 }], rowCount: 1 });
+    expect(mockQuery).toHaveBeenCalledWith('SELECT 1', undefined);
+  });
+
+  it('executes a parameterised query successfully', async () => {
+    mockQuery.mockResolvedValue({ rows: [{ name: 'test' }], rowCount: 1 });
+    const pool = new ManagedPool(defaultOpts, logger);
+
+    const result = await pool.query('SELECT * FROM t WHERE id = $1', [1]);
+
+    expect(result).toEqual({ rows: [{ name: 'test' }], rowCount: 1 });
+    expect(mockQuery).toHaveBeenCalledWith('SELECT * FROM t WHERE id = $1', [1]);
+  });
+
+  it('rejects on query error', async () => {
+    mockQuery.mockRejectedValue(new Error('connection lost'));
+    const pool = new ManagedPool(defaultOpts, logger);
+
+    await expect(pool.query('SELECT 1')).rejects.toThrow('connection lost');
+  });
+
+  it('connects and returns a PoolClient', async () => {
+    const mockClient = { query: vi.fn(), release: vi.fn() };
+    mockConnect.mockResolvedValue(mockClient);
+    const pool = new ManagedPool(defaultOpts, logger);
+
+    const client = await pool.connect();
+
+    expect(client).toBe(mockClient);
+  });
+
+  it('rejects on connect failure', async () => {
+    mockConnect.mockRejectedValue(new Error('too many connections'));
+    const pool = new ManagedPool(defaultOpts, logger);
+
+    await expect(pool.connect()).rejects.toThrow('too many connections');
+  });
+
+  it('returns true on successful ping', async () => {
+    mockQuery.mockResolvedValue({ rows: [{ '?column?': 1 }] });
+    const pool = new ManagedPool(defaultOpts, logger);
+
+    const result = await pool.ping();
+
+    expect(result).toBe(true);
+    expect(mockQuery).toHaveBeenCalledWith('SELECT 1');
+  });
+
+  it('returns false on ping failure', async () => {
+    mockQuery.mockRejectedValue(new Error('connection refused'));
+    const pool = new ManagedPool(defaultOpts, logger);
+
+    const result = await pool.ping();
+
+    expect(result).toBe(false);
+  });
+
+  it('collects and returns pool statistics', () => {
+    const pool = new ManagedPool(defaultOpts, logger);
+    const stats = pool.collectMetrics();
+
+    expect(stats).toEqual({
+      name: 'primary',
+      total: 5,
+      idle: 2,
+      waiting: 0,
+      max: 10,
+      circuitState: 'closed',
+    });
+  });
+
+  it('collects metrics when pool is at capacity', () => {
+    mockPoolInstance.totalCount = 10;
+    mockPoolInstance.idleCount = 0;
+    mockPoolInstance.waitingCount = 5;
+    const pool = new ManagedPool(defaultOpts, logger);
+
+    const stats = pool.collectMetrics();
+
+    expect(stats.total).toBe(10);
+    expect(stats.idle).toBe(0);
+    expect(stats.waiting).toBe(5);
+  });
+
+  it('getCircuitState returns the breaker state', () => {
+    const pool = new ManagedPool(defaultOpts, logger);
+    expect(pool.getCircuitState()).toBe('closed');
+  });
+
+  it('circuit breaker opens on repeated failures', async () => {
+    mockQuery.mockRejectedValue(new Error('db down'));
+    const pool = new ManagedPool(defaultOpts, logger);
+
+    for (let i = 0; i < 3; i++) {
+      await expect(pool.query('SELECT 1')).rejects.toThrow('db down');
+    }
+
+    expect(pool.getCircuitState()).toBe('open');
+  });
+
+  it('ends the pool gracefully', async () => {
+    const pool = new ManagedPool(defaultOpts, logger);
+    await pool.end();
+    expect(mockEnd).toHaveBeenCalled();
+  });
+
+  it('works with replica pool names', () => {
+    const replicaPool = new ManagedPool(
+      { ...defaultOpts, name: 'replica-0' },
+      logger,
+    );
+    expect(replicaPool.name).toBe('replica-0');
+  });
+});

--- a/services/aggregator/tests/oracle-sources.test.ts
+++ b/services/aggregator/tests/oracle-sources.test.ts
@@ -1,0 +1,619 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { httpClient } from '../src/infrastructure/http-client';
+import { ChainlinkSource } from '../src/oracle-sources/chainlink';
+import { RedstoneSource } from '../src/oracle-sources/redstone';
+import { BandSource } from '../src/oracle-sources/band';
+import { ReflectorSource } from '../src/oracle-sources/reflector';
+
+vi.mock('../src/infrastructure/http-client', () => ({
+  httpClient: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock('../src/price-aggregation/source-circuit-breaker', () => ({
+  sourceCircuitBreaker: {
+    isAllowed: vi.fn(() => true),
+    recordSuccess: vi.fn(),
+    recordFailure: vi.fn(),
+  },
+}));
+
+vi.mock('../src/observability/metrics', () => {
+  const mockGauge = { set: vi.fn(), inc: vi.fn() };
+  const mockCounter = { inc: vi.fn() };
+  const mockHistogram = {
+    startTimer: vi.fn(() => (labels?: Record<string, string>) => 0),
+  };
+  return {
+    oracleSourceLatency: mockHistogram,
+    oracleSourceRequestsTotal: mockCounter,
+    oracleSourceSlaBreaches: mockCounter,
+    oracleApiCallsTotal: mockCounter,
+    oracleApiCostTotal: mockCounter,
+    oracleApiBudgetUtilization: mockGauge,
+  };
+});
+
+const mockedHttpClient = vi.mocked(httpClient);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ─────────────────────────────────────────────────────────────
+// ChainlinkSource
+// ─────────────────────────────────────────────────────────────
+describe('ChainlinkSource', () => {
+  it('fetches and normalizes XLM price successfully', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: { USD: { PRICE: 0.12 } },
+    } as never);
+
+    const source = new ChainlinkSource();
+    const price = await source.fetchPrice('XLM');
+
+    expect(price).not.toBeNull();
+    expect(price!.asset).toBe('XLM');
+    expect(price!.decimals).toBe(8);
+    expect(price!.source).toBe('chainlink');
+    expect(price!.price).toBe(12000000n);
+    expect(mockedHttpClient.get).toHaveBeenCalledWith(
+      expect.stringContaining('/price'),
+      expect.objectContaining({
+        params: expect.objectContaining({ fsym: 'XLM' }),
+      }),
+    );
+  });
+
+  it('fetches and normalizes BTC price successfully', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: { USD: { PRICE: 65000.50 } },
+    } as never);
+
+    const source = new ChainlinkSource();
+    const price = await source.fetchPrice('BTC');
+
+    expect(price).not.toBeNull();
+    expect(price!.asset).toBe('BTC');
+    expect(price!.source).toBe('chainlink');
+    expect(price!.price).toBe(6500050000000n);
+  });
+
+  it('returns null when API response has no USD.PRICE', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: { USD: {} },
+    } as never);
+
+    const source = new ChainlinkSource();
+    const price = await source.fetchPrice('XLM');
+
+    expect(price).toBeNull();
+  });
+
+  it('returns null when API response has no USD at all', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: {},
+    } as never);
+
+    const source = new ChainlinkSource();
+    const price = await source.fetchPrice('XLM');
+
+    expect(price).toBeNull();
+  });
+
+  it('returns null when API response data is null', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: null,
+    } as never);
+
+    const source = new ChainlinkSource();
+    const price = await source.fetchPrice('XLM');
+
+    expect(price).toBeNull();
+  });
+
+  it('returns null on network error (via fetchWithBackoff)', async () => {
+    mockedHttpClient.get.mockRejectedValue(new Error('Network error'));
+
+    const source = new ChainlinkSource();
+    const price = await source.fetchWithBackoff('XLM');
+
+    expect(price).toBeNull();
+  });
+
+  it('returns null on timeout error (via fetchWithBackoff)', async () => {
+    mockedHttpClient.get.mockRejectedValue(new Error('timeout of 5000ms exceeded'));
+
+    const source = new ChainlinkSource();
+    const price = await source.fetchWithBackoff('XLM');
+
+    expect(price).toBeNull();
+  });
+
+  it('handles malformed response — PRICE is null', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: { USD: { PRICE: null } },
+    } as never);
+
+    const source = new ChainlinkSource();
+    const price = await source.fetchPrice('XLM');
+
+    expect(price).toBeNull();
+  });
+
+  it('maps USDC symbol correctly', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: { USD: { PRICE: 1.0 } },
+    } as never);
+
+    const source = new ChainlinkSource();
+    const price = await source.fetchPrice('USDC');
+
+    expect(price).not.toBeNull();
+    expect(price!.asset).toBe('USDC');
+    expect(mockedHttpClient.get).toHaveBeenCalledWith(
+      expect.stringContaining('/price'),
+      expect.objectContaining({
+        params: expect.objectContaining({ fsym: 'USDC' }),
+      }),
+    );
+  });
+
+  it('maps USDT symbol correctly', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: { USD: { PRICE: 1.0 } },
+    } as never);
+
+    const source = new ChainlinkSource();
+    await source.fetchPrice('USDT');
+
+    expect(mockedHttpClient.get).toHaveBeenCalledWith(
+      expect.stringContaining('/price'),
+      expect.objectContaining({
+        params: expect.objectContaining({ fsym: 'USDT' }),
+      }),
+    );
+  });
+
+  it('falls back to original asset for unmapped symbol', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: { USD: { PRICE: 100 } },
+    } as never);
+
+    const source = new ChainlinkSource();
+    await source.fetchPrice('unknown');
+
+    expect(mockedHttpClient.get).toHaveBeenCalledWith(
+      expect.stringContaining('/price'),
+      expect.objectContaining({
+        params: expect.objectContaining({ fsym: 'unknown' }),
+      }),
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// RedstoneSource
+// ─────────────────────────────────────────────────────────────
+describe('RedstoneSource', () => {
+  it('fetches and normalizes BTC price successfully', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: { BTC: { value: '65000', decimals: 8 } },
+    } as never);
+
+    const source = new RedstoneSource();
+    const price = await source.fetchPrice('BTC');
+
+    expect(price).not.toBeNull();
+    expect(price!.asset).toBe('BTC');
+    expect(price!.source).toBe('redstone');
+    expect(price!.decimals).toBe(8);
+    expect(price!.price).toBe(6500000000000n);
+  });
+
+  it('fetches and normalizes ETH price with default decimals=8', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: { ETH: { value: '3500' } },
+    } as never);
+
+    const source = new RedstoneSource();
+    const price = await source.fetchPrice('ETH');
+
+    expect(price).not.toBeNull();
+    expect(price!.decimals).toBe(8);
+    expect(price!.price).toBe(350000000000n);
+  });
+
+  it('returns null when asset not in response data', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: {},
+    } as never);
+
+    const source = new RedstoneSource();
+    const price = await source.fetchPrice('XLM');
+
+    expect(price).toBeNull();
+  });
+
+  it('returns null when value is missing', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: { XLM: { decimals: 8 } },
+    } as never);
+
+    const source = new RedstoneSource();
+    const price = await source.fetchPrice('XLM');
+
+    expect(price).toBeNull();
+  });
+
+  it('returns null when data is null', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: null,
+    } as never);
+
+    const source = new RedstoneSource();
+    const price = await source.fetchPrice('XLM');
+
+    expect(price).toBeNull();
+  });
+
+  it('returns null on network error (via fetchWithBackoff)', async () => {
+    mockedHttpClient.get.mockRejectedValue(new Error('Network error'));
+
+    const source = new RedstoneSource();
+    const price = await source.fetchWithBackoff('XLM');
+
+    expect(price).toBeNull();
+  });
+
+  it('returns null on ECONNREFUSED error (via fetchWithBackoff)', async () => {
+    mockedHttpClient.get.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const source = new RedstoneSource();
+    const price = await source.fetchWithBackoff('XLM');
+
+    expect(price).toBeNull();
+  });
+
+  it('returns null on timeout error (via fetchWithBackoff)', async () => {
+    mockedHttpClient.get.mockRejectedValue(new Error('timeout of 5000ms exceeded'));
+
+    const source = new RedstoneSource();
+    const price = await source.fetchWithBackoff('XLM');
+
+    expect(price).toBeNull();
+  });
+
+  it('handles malformed response — value is empty string', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: { XLM: { value: '' } },
+    } as never);
+
+    const source = new RedstoneSource();
+    const price = await source.fetchPrice('XLM');
+
+    expect(price).toBeNull();
+  });
+
+  it('uppercases asset symbol in request params', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: { XLM: { value: '0.12', decimals: 8 } },
+    } as never);
+
+    const source = new RedstoneSource();
+    await source.fetchPrice('xlm');
+
+    expect(mockedHttpClient.get).toHaveBeenCalledWith(
+      expect.stringContaining('/prices'),
+      expect.objectContaining({
+        params: expect.objectContaining({ symbols: 'XLM' }),
+      }),
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// BandSource
+// ─────────────────────────────────────────────────────────────
+describe('BandSource', () => {
+  it('fetches and normalizes ETH price successfully', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: {
+        data: { price: '3500000000000000000000', decimals: 18, updated_at: 1719000000 },
+      },
+    } as never);
+
+    const source = new BandSource();
+    const price = await source.fetchPrice('ETH');
+
+    expect(price).not.toBeNull();
+    expect(price!.asset).toBe('ETH');
+    expect(price!.source).toBe('band');
+    expect(price!.decimals).toBe(18);
+    expect(price!.price).toBe(3500000000000000000000000000000000000000n);
+    expect(price!.timestamp).toBe(1719000000);
+  });
+
+  it('fetches and normalizes XLM price with default decimals=9', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: {
+        data: { price: '12000000', updated_at: 1719000000 },
+      },
+    } as never);
+
+    const source = new BandSource();
+    const price = await source.fetchPrice('XLM');
+
+    expect(price).not.toBeNull();
+    expect(price!.decimals).toBe(9);
+    expect(price!.price).toBe(12000000000000000n);
+  });
+
+  it('uses current time when updated_at is missing', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    mockedHttpClient.get.mockResolvedValue({
+      data: { data: { price: '12000000' } },
+    } as never);
+
+    const source = new BandSource();
+    const price = await source.fetchPrice('XLM');
+
+    expect(price).not.toBeNull();
+    expect(price!.timestamp).toBe(now);
+  });
+
+  it('returns null when data.data.price is missing', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: { data: {} },
+    } as never);
+
+    const source = new BandSource();
+    const price = await source.fetchPrice('XLM');
+
+    expect(price).toBeNull();
+  });
+
+  it('returns null when data.data is null', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: { data: null },
+    } as never);
+
+    const source = new BandSource();
+    const price = await source.fetchPrice('XLM');
+
+    expect(price).toBeNull();
+  });
+
+  it('returns null when data is null', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: null,
+    } as never);
+
+    const source = new BandSource();
+    const price = await source.fetchPrice('XLM');
+
+    expect(price).toBeNull();
+  });
+
+  it('returns null on network error (via fetchWithBackoff)', async () => {
+    mockedHttpClient.get.mockRejectedValue(new Error('Network error'));
+
+    const source = new BandSource();
+    const price = await source.fetchWithBackoff('XLM');
+
+    expect(price).toBeNull();
+  });
+
+  it('returns null on timeout error (via fetchWithBackoff)', async () => {
+    mockedHttpClient.get.mockRejectedValue(new Error('ETIMEDOUT'));
+
+    const source = new BandSource();
+    const price = await source.fetchWithBackoff('XLM');
+
+    expect(price).toBeNull();
+  });
+
+  it('maps USDC to USDC-USD', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: { data: { price: '100000000', decimals: 8 } },
+    } as never);
+
+    const source = new BandSource();
+    await source.fetchPrice('USDC');
+
+    expect(mockedHttpClient.get).toHaveBeenCalledWith(
+      expect.stringContaining('/oracle/v1/feeds/USDC-USD'),
+    );
+  });
+
+  it('maps BTC to BTC-USD', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: { data: { price: '6500000000000', decimals: 8 } },
+    } as never);
+
+    const source = new BandSource();
+    await source.fetchPrice('BTC');
+
+    expect(mockedHttpClient.get).toHaveBeenCalledWith(
+      expect.stringContaining('/oracle/v1/feeds/BTC-USD'),
+    );
+  });
+
+  it('falls back to {symbol}-USD for unknown assets', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: { data: { price: '100' } },
+    } as never);
+
+    const source = new BandSource();
+    await source.fetchPrice('DOGE');
+
+    expect(mockedHttpClient.get).toHaveBeenCalledWith(
+      expect.stringContaining('/oracle/v1/feeds/DOGE-USD'),
+    );
+  });
+
+  it('rejects on malformed non-numeric price', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: { data: { price: 'not-a-number' } },
+    } as never);
+
+    const source = new BandSource();
+    await expect(source.fetchPrice('XLM')).rejects.toThrow();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// ReflectorSource
+// ─────────────────────────────────────────────────────────────
+describe('ReflectorSource', () => {
+  it('fetches and normalizes USDC price successfully', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: {
+        prices: { 'Crypto.USDC/USD': { price: '1.00', decimals: 8, timestamp: 1719000000 } },
+      },
+    } as never);
+
+    const source = new ReflectorSource();
+    const price = await source.fetchPrice('USDC');
+
+    expect(price).not.toBeNull();
+    expect(price!.asset).toBe('USDC');
+    expect(price!.source).toBe('reflector');
+    expect(price!.decimals).toBe(8);
+    expect(price!.price).toBe(100000000n);
+    expect(price!.timestamp).toBe(1719000000);
+  });
+
+  it('fetches and normalizes XLM price with default decimals=8', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: {
+        prices: { 'Crypto.XLM/USD': { price: '0.12' } },
+      },
+    } as never);
+
+    const source = new ReflectorSource();
+    const price = await source.fetchPrice('XLM');
+
+    expect(price).not.toBeNull();
+    expect(price!.decimals).toBe(8);
+    expect(price!.price).toBe(12000000n);
+  });
+
+  it('uses current time when timestamp is missing', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    mockedHttpClient.get.mockResolvedValue({
+      data: { prices: { 'Crypto.XLM/USD': { price: '0.12', decimals: 8 } } },
+    } as never);
+
+    const source = new ReflectorSource();
+    const price = await source.fetchPrice('XLM');
+
+    expect(price).not.toBeNull();
+    expect(price!.timestamp).toBe(now);
+  });
+
+  it('returns null when prices object is missing', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: {},
+    } as never);
+
+    const source = new ReflectorSource();
+    const price = await source.fetchPrice('XLM');
+
+    expect(price).toBeNull();
+  });
+
+  it('returns null when asset symbol not in prices', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: { prices: {} },
+    } as never);
+
+    const source = new ReflectorSource();
+    const price = await source.fetchPrice('XLM');
+
+    expect(price).toBeNull();
+  });
+
+  it('returns null when price field is missing', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: { prices: { 'Crypto.XLM/USD': { decimals: 8 } } },
+    } as never);
+
+    const source = new ReflectorSource();
+    const price = await source.fetchPrice('XLM');
+
+    expect(price).toBeNull();
+  });
+
+  it('returns null when data is null', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: null,
+    } as never);
+
+    const source = new ReflectorSource();
+    const price = await source.fetchPrice('XLM');
+
+    expect(price).toBeNull();
+  });
+
+  it('returns null on network error (via fetchWithBackoff)', async () => {
+    mockedHttpClient.get.mockRejectedValue(new Error('Network error'));
+
+    const source = new ReflectorSource();
+    const price = await source.fetchWithBackoff('XLM');
+
+    expect(price).toBeNull();
+  });
+
+  it('returns null on ETIMEDOUT error (via fetchWithBackoff)', async () => {
+    mockedHttpClient.get.mockRejectedValue(new Error('ETIMEDOUT'));
+
+    const source = new ReflectorSource();
+    const price = await source.fetchWithBackoff('XLM');
+
+    expect(price).toBeNull();
+  });
+
+  it('constructs correct symbol format', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: { prices: { 'Crypto.BTC/USD': { price: '65000', decimals: 8 } } },
+    } as never);
+
+    const source = new ReflectorSource();
+    await source.fetchPrice('BTC');
+
+    expect(mockedHttpClient.get).toHaveBeenCalledWith(
+      expect.stringContaining('/v1/prices'),
+      expect.objectContaining({
+        params: expect.objectContaining({ asset: 'Crypto.BTC/USD' }),
+      }),
+    );
+  });
+
+  it('handles malformed response — price is empty string', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: { prices: { 'Crypto.XLM/USD': { price: '' } } },
+    } as never);
+
+    const source = new ReflectorSource();
+    const price = await source.fetchPrice('XLM');
+
+    expect(price).toBeNull();
+  });
+
+  it('handles malformed response — price is null', async () => {
+    mockedHttpClient.get.mockResolvedValue({
+      data: { prices: { 'Crypto.XLM/USD': { price: null } } },
+    } as never);
+
+    const source = new ReflectorSource();
+    const price = await source.fetchPrice('XLM');
+
+    expect(price).toBeNull();
+  });
+});


### PR DESCRIPTION

Closes #287
Closes #288
Closes #289
Closes #290

## Summary

Adds comprehensive unit tests for all four oracle source modules and three database infrastructure modules.

### New test files

| File | Tests | Coverage |
|------|-------|----------|
| `services/aggregator/tests/oracle-sources.test.ts` | 45 | Chainlink, Redstone, Band, Reflector — success, error, timeout, malformed, null data, empty strings, symbol mapping |
| `api/tests/database.test.ts` | 27 | DatabaseClient — init, schema, TimescaleDB, query/readQuery, replica routing, fallback, historical queries, pool stats, disconnect |
| `api/tests/db-pool.test.ts` | 16 | ManagedPool — constructor, query, connect, ping, collectMetrics, circuit breaker |
| `api/tests/db-health-monitor.test.ts` | 21 | DbHealthMonitor — healthy/degraded/critical states, connection exhaustion, circuit open, slow probe, replication lag |

### Existing tests (also passing)
- `api/tests/db-retry.test.ts` — 4 tests
- `api/tests/db-circuit-breaker.test.ts` — 4 tests

**Total: 117 tests, all passing.**

### Approach
- Oracle sources: mocked `httpClient` with vitest, covering all response shapes per source
- Database modules: mocked `pg` Pool using named function constructors (arrow functions can't be `new`'d), and mocked `prom-client` for health monitor tests