### PR TITLE
docs(security,governance): mainnet runbook, sandbox review, governance, threat model

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# Code owners route review requests for changes in each area.
+# See docs/GOVERNANCE.md for the branch protection rules that enforce this.
+
+# Default owners for anything not matched below
+*                       @knytcomics-ui
+
+# Soroban contract changes
+/contracts/             @knytcomics-ui
+
+# API service changes
+/api/                   @knytcomics-ui
+
+# Infrastructure / deployment changes
+/infrastructure/        @knytcomics-ui
+/k8s/                   @knytcomics-ui
+/.github/workflows/     @knytcomics-ui

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -1,0 +1,51 @@
+# Repository Governance
+
+Controls required so unreviewed or unauthorized changes cannot reach `main`.
+
+## Code owners
+
+`.github/CODEOWNERS` routes review requests by path (contract, API, infra).
+GitHub requires a CODEOWNERS-matched reviewer's approval automatically once
+branch protection (below) has "Require review from Code Owners" enabled.
+
+## Required branch protection settings for `main`
+
+To be applied by a repository admin (Settings → Branches → Branch protection
+rules → `main`), or via the API:
+
+```bash
+gh api -X PUT repos/Stellar-Unified-Price-Oracle/-Stellar-Unified-Price-Oracle-Aggregator-API-Backend/branches/main/protection \
+  --input - <<'JSON'
+{
+  "required_status_checks": { "strict": true, "contexts": ["ci"] },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1,
+    "require_code_owner_reviews": true
+  },
+  "restrictions": null,
+  "required_signatures": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+JSON
+```
+
+This enforces:
+
+- At least one approving review before merge, with Code Owners required for
+  paths they own.
+- The `ci` status check must pass before merge.
+- Signed commits are required on `main` (`required_signatures`).
+- No force pushes or branch deletion on `main`.
+
+## Signed commits
+
+Contributors must configure commit signing (GPG or SSH) locally:
+
+```bash
+git config commit.gpgsign true
+```
+
+GitHub verifies signatures against keys added to the contributor's account
+under Settings → SSH and GPG keys.

--- a/docs/SANDBOX_SECURITY_REVIEW.md
+++ b/docs/SANDBOX_SECURITY_REVIEW.md
@@ -1,0 +1,39 @@
+# Programmable Feed & Plugin Sandbox — Security Review
+
+Scope: `api/src/feeds/programmable-feeds.ts`, the DSL that backs user-defined
+("programmable") feeds and the `wasm-plugin` aggregation strategy.
+
+## Current implementation
+
+As of this review, `programmable-feeds.ts` implements only the **declaration,
+validation, gas-estimation, marketplace, and health-metering** layers of
+programmable feeds. `validateFeedDefinition` requires a `wasmPluginId` when
+`aggregation.strategy === 'wasm-plugin'`, but there is no WASM execution
+runtime in this repository yet — no host that loads, instantiates, or invokes
+plugin bytecode. Consequently there is currently **no attack surface** for
+resource-exhaustion, memory-bound violation, or filesystem-escape attacks
+against a plugin sandbox, because no plugin ever runs.
+
+## Guarantees required before a plugin runtime ships
+
+Before any WASM execution host is added, it must provide and be tested against:
+
+- **CPU/time bounding**: a hard wall-clock and fuel/instruction-count limit per
+  invocation (e.g. Wasmtime `fuel_consumed` metering), independent of the
+  existing `timeoutMs` field on `FeedSourceDeclaration`, which only bounds
+  network source fetches today.
+- **Memory bounding**: a fixed linear-memory ceiling per plugin instance with
+  no growth beyond it, enforced by the WASM engine's memory limiter, not by
+  the plugin's own code.
+- **No host filesystem/network access**: the plugin's import surface must be
+  limited to pure computation (numeric aggregation inputs/outputs only) — no
+  WASI filesystem, socket, or environment-variable imports linked in.
+- **No cross-plugin state leakage**: each invocation gets a fresh instance;
+  no shared linear memory or global state between tenants.
+
+## Recommendation
+
+Track the WASM execution host as separate implementation work; red-team it
+(resource exhaustion, memory-bound, filesystem/network escape attempts) once
+it exists, and add regression tests at that point covering each guarantee
+above. Re-run this review whenever the plugin runtime is introduced.

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -1,0 +1,55 @@
+# Threat Model — Mainnet Topology
+
+Covers the current multi-region, post-quantum (PQ), and governance-enabled
+architecture. Supersedes any earlier single-region MVP assumptions.
+
+## Trust boundaries
+
+1. **External price sources → aggregation service** — Chainlink, Redstone,
+   Band, Reflector, and third-party programmable/WASM feed sources are
+   untrusted inputs.
+2. **API service → Soroban contract** — the API submits price updates and
+   reads contract state over RPC; the contract is the source of truth.
+3. **Client → API service** — public HTTP surface, untrusted callers.
+4. **Region → region (multi-region/active-active)** — replication and
+   failover traffic between deployment regions.
+5. **Marketplace plugin authors → plugin runtime** — third-party WASM/DSL
+   feed definitions submitted for execution (see
+   `docs/SANDBOX_SECURITY_REVIEW.md`).
+6. **CI/CD → production** — build and deploy pipeline with the power to ship
+   code and, for contracts, deploy immutable on-chain logic.
+
+## Attacker profiles
+
+| Profile | Capability | Primary targets |
+|---|---|---|
+| Malicious price source | Controls one upstream feed's reported price | Aggregation/median logic, deviation guards |
+| Malicious plugin author | Submits a crafted programmable feed / WASM plugin | Plugin sandbox, host resources |
+| Network attacker | MITM/DoS on RPC or source connections | Availability, staleness guards |
+| Compromised CI credential | Write access to build/deploy pipeline | Supply chain, mainnet contract deploys |
+| Malicious/careless contributor | Opens PRs against the repo | Unreviewed code reaching `main` |
+| Future quantum adversary | Breaks classical signature schemes | Long-lived signed data, PQ migration window (see `docs/PQ_READINESS.md`) |
+
+## Threats and mitigations
+
+| Threat | Mitigation | Status / tracking |
+|---|---|---|
+| Single malicious/faulty source skews the reported price | Multi-source aggregation with configurable `minSources`, deviation bounds (`maxDeviationBps`), staleness guards | Implemented (`FeedGuards`) |
+| Stale data reported as live | `stalenessSeconds` guard per feed | Implemented |
+| Plugin sandbox escape or resource exhaustion | No WASM execution host exists yet; guarantees required before one ships are documented | Tracked — `docs/SANDBOX_SECURITY_REVIEW.md` |
+| Unauthorized/unreviewed change merged to `main` | Required PR reviews, CI status checks, CODEOWNERS routing, signed commits | Tracked — `docs/GOVERNANCE.md`, `.github/CODEOWNERS` |
+| Compromised deploy credentials push a malicious mainnet contract | Mainnet deploys follow a documented, verifiable runbook; contracts are immutable once deployed, limiting blast radius to a single bad instance | Tracked — `docs/runbooks/mainnet-deployment.md` |
+| Region failover injects stale or conflicting state | Active-active replication design | See `docs/active-active-multi-region.md` |
+| Classical signatures broken by a future quantum adversary | PQ signature migration plan | See `docs/PQ_READINESS.md` |
+| CI/CD compromise ships malicious code | Branch protection + required status checks prevent bypassing CI | Tracked — `docs/GOVERNANCE.md` |
+
+## Review cadence
+
+This document must be reviewed:
+
+- In the run-up to mainnet launch.
+- After any major feature addition (e.g. a new region, a new source
+  integration, the WASM plugin execution host).
+
+Update the threats table above with new entries and link each to its owning
+issue or doc when a control is only partially implemented.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,9 @@ Welcome to the Stellar Unified Price Oracle Aggregator API documentation.
 - [ADRs](./adr/) — Architecture Decision Records
 - [Runbooks](./runbooks/) — operational runbooks
 - [OpenAPI spec](../api/src/services/openapi.ts) — Swagger UI at `/api/v1/docs`
+- [Threat Model](./THREAT_MODEL.md) — mainnet trust boundaries, attacker profiles, mitigations
+- [Governance](./GOVERNANCE.md) — branch protection, signed commits, CODEOWNERS
+- [Sandbox Security Review](./SANDBOX_SECURITY_REVIEW.md) — programmable feed / plugin sandbox review
 
 ## Architecture overview
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -27,6 +27,7 @@ This directory contains operational runbooks for diagnosing and resolving incide
 | Soroban contract call failures | [contract-failures.md](contract-failures.md) |
 | High API error rate | [high-error-rate.md](high-error-rate.md) |
 | Database connectivity issues | [database-issues.md](database-issues.md) |
+| Mainnet deployment | [mainnet-deployment.md](mainnet-deployment.md) |
 
 ## Post-Mortem
 

--- a/docs/runbooks/mainnet-deployment.md
+++ b/docs/runbooks/mainnet-deployment.md
@@ -1,0 +1,69 @@
+# Mainnet Deployment Runbook
+
+Repeatable, reviewable steps for deploying the oracle contract to Stellar mainnet.
+
+## Prerequisites
+
+- A funded mainnet account dedicated to deployment (not a personal key).
+- `soroban-cli` configured with a `mainnet` network alias.
+- Access to the CI-managed secrets store for the deployer key.
+- Sign-off from a second engineer (see `.github/CODEOWNERS`) before running any step against mainnet.
+
+## 1. Initialize the contract
+
+```bash
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/oracle_contract.wasm \
+  --source deployer --network mainnet
+# record the returned CONTRACT_ID
+soroban contract invoke --id $CONTRACT_ID --source deployer --network mainnet \
+  -- initialize --admin $ADMIN_ADDRESS
+```
+
+Verify:
+
+```bash
+soroban contract invoke --id $CONTRACT_ID --source deployer --network mainnet -- get_admin
+```
+
+## 2. Register price sources
+
+```bash
+soroban contract invoke --id $CONTRACT_ID --source deployer --network mainnet \
+  -- register_source --source_id chainlink --address $CHAINLINK_ADDR
+```
+
+Repeat per source. Verify with `-- list_sources`.
+
+## 3. Configure trusted assets
+
+```bash
+soroban contract invoke --id $CONTRACT_ID --source deployer --network mainnet \
+  -- add_trusted_asset --asset $ASSET_CODE --issuer $ISSUER_ADDRESS
+```
+
+Verify with `-- list_trusted_assets`.
+
+## 4. Register CONTRACT_ID with the API layer
+
+- Set `ORACLE_CONTRACT_ID=$CONTRACT_ID` in the mainnet environment config (see `config/`).
+- Restart/redeploy the API service so it reads the new contract ID.
+- Verify: `curl https://<api-host>/health` reports the configured contract ID and reachable RPC endpoint.
+
+## Verification checklist
+
+- [ ] `get_admin` returns the expected admin address.
+- [ ] `list_sources` matches the intended source set.
+- [ ] `list_trusted_assets` matches the intended asset set.
+- [ ] API `/health` reports the new `CONTRACT_ID` and healthy RPC connectivity.
+- [ ] A test price submission and read round-trips correctly.
+
+## Rollback
+
+- The API layer can be rolled back independently by reverting `ORACLE_CONTRACT_ID` to the previous contract and redeploying — the prior contract instance remains live and unaffected.
+- Soroban contracts are immutable once deployed; there is no in-place rollback of a bad contract. If a deployed contract is misconfigured, deploy a corrected instance under a new `CONTRACT_ID` and repeat steps 1–4, then repoint the API layer.
+- Keep the previous `CONTRACT_ID` recorded in the deployment log until the new instance has been verified in production for at least 24 hours.
+
+## Testing this runbook
+
+This runbook must be exercised end-to-end on `testnet` first, then on a fresh mainnet account, before being used for a production deployment. Record the `CONTRACT_ID` and verification output from both runs in the deployment log.


### PR DESCRIPTION
## Summary
- Adds a mainnet deployment runbook (initialize, source registration, trusted assets, CONTRACT_ID registration, verification, rollback).
- Adds a sandbox security review of the programmable feed / WASM plugin path — documents that no plugin execution runtime exists yet, so there is currently no attack surface, and specifies the guarantees required before one ships.
- Adds `.github/CODEOWNERS` and `docs/GOVERNANCE.md` documenting the branch protection settings (required reviews, required status checks, required signatures, no force-push/delete) needed to satisfy the repo governance requirements; applying the protection rule itself requires a repo admin action (see the `gh api` command in the doc).
- Adds `docs/THREAT_MODEL.md` covering trust boundaries, attacker profiles, and mitigations for the current multi-region/PQ/governance topology.

Closes #374
Closes #373
Closes #372
Closes #371

## Validation performed
- Docs-only change plus one new `.github/CODEOWNERS` file; no source code modified.
- `git push` pre-push hook ran the aggregator/API TypeScript builds successfully (no compile errors introduced).