### PR TITLE
Add on-call escalation routing and runbook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,6 +137,8 @@ ALERT_WEBHOOK_URL=
 ALERT_SLACK_WEBHOOK_URL=
 # PagerDuty Events API v2 integration/routing key.
 ALERT_PAGERDUTY_ROUTING_KEY=
+# Opsgenie API key for degraded / warning routes.
+ALERT_OPSGENIE_API_KEY=
 # Transactional email API webhook (e.g. SendGrid/Mailgun inbound proxy) and comma-separated recipients.
 ALERT_EMAIL_WEBHOOK_URL=
 ALERT_EMAIL_RECIPIENTS=

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -13,9 +13,67 @@ This directory contains operational runbooks for diagnosing and resolving incide
 
 ## Escalation Path
 
-1. **On-call engineer** — primary responder; owns the incident until resolved or escalated
-2. **Team lead** — escalate if not mitigated within 2× SLA or if P0/P1
-3. **Engineering manager** — escalate for customer-facing P0 exceeding 30 min
+1. **Primary on-call engineer** — primary responder; owns the incident until acked, mitigated, or handed over
+2. **Team lead** — escalated for any P1 or prolonged P2 issue that exceeds 2× the SLA or after 1 hour without actionable mitigation
+3. **Engineering manager** — escalated for all P0 incidents, customer-facing outages, or if the incident exceeds 30 minutes without recovery
+
+## On-call Rotation and Handoff
+
+- Rotation owner: the primary on-call is assigned in PagerDuty with a 24/7 weekly rotation.
+- Secondary coverage: the backup on-call is assigned to the same service and must be in the escalation chain for all P1/P0 alerts.
+- Handoff window: the outgoing engineer must notify the incoming engineer via Slack or PagerDuty before the shift changes.
+- Shadowing requirement: the outgoing engineer remains on the call for the first 30 minutes of the new rotation during a handoff, and the incoming engineer must acknowledge the incident channel before taking over ownership.
+- Acknowledge by: the on-call responder must acknowledge the page within the alert SLA window; unacknowledged alerts escalate automatically according to the route policy below.
+
+## Severity to Escalation Mapping
+
+| Alert / Condition | Severity | Primary channel | Primary target | Secondary target | Acknowledge SLA |
+|---|---|---|---|---|---|
+| All sources down / contract outage / critical SLA breach | P0 / critical | PagerDuty | primary-oncall | engineering-manager | 15 min |
+| Stale feed / degraded upstream / degraded health | P1 / warning | Opsgenie | primary-oncall | team-lead | 30 min |
+| Single-source drift / minor anomaly / non-user-impacting noise | P2/P3 / info | Slack | team-channel | none | 4 hours |
+
+> Production routing must only page humans; automated retries and status-only notifications remain in the team channel.
+
+## Test Page and Validation
+
+1. Run a synthetic page from the PagerDuty or Opsgenie staging environment using the production service key and a known test alert.
+2. Verify that the alert reaches the configured on-call contact in the expected channel within 2 minutes.
+3. Acknowledge the page and confirm the escalation path is recorded in the incident timeline.
+4. Trigger the secondary escalation only after the acknowledgement timeout is exceeded to confirm the manager or lead receives the callback.
+5. Document the test result in the operations log with the alert ID, the timestamp, and the responder that acknowledged it.
+
+### Example test page command
+
+```bash
+curl -X POST https://events.pagerduty.com/v2/enqueue \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "routing_key": "${PAGERDUTY_PROD_ROUTING_KEY}",
+    "event_action": "trigger",
+    "dedup_key": "ops-rotation-test-$(date +%s)",
+    "payload": {
+      "summary": "PagerDuty test page for production on-call verification",
+      "source": "stellar-price-oracle-ops-test",
+      "severity": "critical",
+      "custom_details": {
+        "alert_type": "source_down",
+        "runbook": "docs/runbooks/oracle-source-down.md",
+        "owner": "primary-oncall"
+      }
+    }
+  }'
+```
+
+## Runbooks Index
+
+- [oracle-source-down.md](oracle-source-down.md)
+- [price-feed-stale.md](price-feed-stale.md)
+- [price-anomaly.md](price-anomaly.md)
+- [contract-failures.md](contract-failures.md)
+- [high-error-rate.md](high-error-rate.md)
+- [database-issues.md](database-issues.md)
+- [mainnet-deployment.md](mainnet-deployment.md)
 
 ## Runbooks Index
 

--- a/services/aggregator/src/index.ts
+++ b/services/aggregator/src/index.ts
@@ -45,6 +45,7 @@ const alertManager = new AlertManager({
   webhookUrl: process.env.ALERT_WEBHOOK_URL ? decryptSecret(process.env.ALERT_WEBHOOK_URL) : undefined,
   slackWebhookUrl: process.env.ALERT_SLACK_WEBHOOK_URL ? decryptSecret(process.env.ALERT_SLACK_WEBHOOK_URL) : undefined,
   pagerDutyRoutingKey: process.env.ALERT_PAGERDUTY_ROUTING_KEY ? decryptSecret(process.env.ALERT_PAGERDUTY_ROUTING_KEY) : undefined,
+  opsGenieApiKey: process.env.ALERT_OPSGENIE_API_KEY ? decryptSecret(process.env.ALERT_OPSGENIE_API_KEY) : undefined,
   emailWebhookUrl: process.env.ALERT_EMAIL_WEBHOOK_URL ? decryptSecret(process.env.ALERT_EMAIL_WEBHOOK_URL) : undefined,
   emailRecipients: (process.env.ALERT_EMAIL_RECIPIENTS || '').split(',').map((s) => s.trim()).filter(Boolean),
   sourceDisagreementThresholdPercent: parseFloat(process.env.ALERT_SOURCE_DISAGREEMENT_PERCENT || '5'),

--- a/services/aggregator/src/observability/alert-manager.ts
+++ b/services/aggregator/src/observability/alert-manager.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { AggregatedPrice } from '../infrastructure/types';
 import { logger } from './logger';
 import { WebSocketServer } from '../infrastructure/ws-server';
+import { resolveEscalationRoute } from './escalation-policy';
 
 export interface AlertThresholds {
   asset: string;
@@ -36,6 +37,8 @@ export interface AlertConfig {
   slackWebhookUrl?: string;
   /** PagerDuty Events API v2 integration/routing key */
   pagerDutyRoutingKey?: string;
+  /** Opsgenie API key for routed incidents */
+  opsGenieApiKey?: string;
   /** Generic transactional email API webhook (e.g. SendGrid/Mailgun) */
   emailWebhookUrl?: string;
   emailRecipients?: string[];
@@ -241,12 +244,24 @@ class AlertManager {
   private async emitAlert(alert: AlertEvent): Promise<void> {
     this.alertHistory.push(alert);
 
+    const escalation = resolveEscalationRoute({
+      type: alert.type,
+      asset: alert.asset,
+      message: alert.message,
+    });
+
     if (this.config.enableConsoleLog) {
-      this.logToConsole(alert);
+      this.logToConsole({
+        ...alert,
+        message: `${alert.message} | escalation=${escalation.severity}/${escalation.primaryChannel}/${escalation.primaryTarget}`,
+      });
     }
 
     if (this.config.enableFileLog && this.config.alertHistoryPath) {
-      this.logToFile(alert);
+      this.logToFile({
+        ...alert,
+        message: `${alert.message} | escalation=${escalation.severity}/${escalation.primaryChannel}/${escalation.primaryTarget}`,
+      });
     }
 
     const wss = WebSocketServer.getInstance();
@@ -264,6 +279,10 @@ class AlertManager {
 
     if (this.config.pagerDutyRoutingKey) {
       await this.sendPagerDuty(alert);
+    }
+
+    if (this.config.opsGenieApiKey) {
+      await this.sendOpsgenie(alert);
     }
 
     if (this.config.emailWebhookUrl) {
@@ -310,6 +329,37 @@ class AlertManager {
       }
     } catch (error) {
       logger.error('Failed to deliver PagerDuty alert:', (error as Error).message);
+    }
+  }
+
+  private async sendOpsgenie(alert: AlertEvent): Promise<void> {
+    try {
+      const priority = alert.type === 'source_down' || alert.type === 'sla_breach' ? 'P1' : 'P3';
+      const response = await fetch('https://api.opsgenie.com/v2/alerts', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `GenieKey ${this.config.opsGenieApiKey}`,
+        },
+        body: JSON.stringify({
+          message: alert.message,
+          description: `${alert.asset}: ${alert.type} alert triggered. Runbook: docs/runbooks/README.md`,
+          alias: `${alert.asset}:${alert.type}`,
+          priority,
+          tags: ['price-oracle', alert.asset, alert.type],
+          details: {
+            asset: alert.asset,
+            type: alert.type,
+            summary: alert.message,
+            timestamp: alert.timestamp,
+          },
+        }),
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+    } catch (error) {
+      logger.error('Failed to deliver Opsgenie alert:', (error as Error).message);
     }
   }
 

--- a/services/aggregator/src/observability/escalation-policy.ts
+++ b/services/aggregator/src/observability/escalation-policy.ts
@@ -1,0 +1,54 @@
+export type AlertType = 'deviation' | 'stale' | 'source_down' | 'sla_breach';
+
+export type EscalationSeverity = 'critical' | 'warning' | 'info';
+export type EscalationChannel = 'pagerduty' | 'opsgenie' | 'slack';
+
+export interface EscalationPolicyInput {
+  type: AlertType;
+  asset: string;
+  message: string;
+}
+
+export interface EscalationRoute {
+  severity: EscalationSeverity;
+  primaryChannel: EscalationChannel;
+  primaryTarget: 'primary-oncall' | 'team-channel';
+  secondaryTarget: 'engineering-manager' | 'team-lead' | 'none';
+  ackWindowMinutes: number;
+  runbook: string;
+}
+
+export function resolveEscalationRoute(input: EscalationPolicyInput): EscalationRoute {
+  const message = input.message.toLowerCase();
+
+  if (input.type === 'source_down' || input.type === 'sla_breach' || message.includes('all sources down') || message.includes('critical')) {
+    return {
+      severity: 'critical',
+      primaryChannel: 'pagerduty',
+      primaryTarget: 'primary-oncall',
+      secondaryTarget: 'engineering-manager',
+      ackWindowMinutes: 15,
+      runbook: 'docs/runbooks/oracle-source-down.md',
+    };
+  }
+
+  if (input.type === 'stale' || message.includes('stale') || message.includes('degraded')) {
+    return {
+      severity: 'warning',
+      primaryChannel: 'opsgenie',
+      primaryTarget: 'primary-oncall',
+      secondaryTarget: 'team-lead',
+      ackWindowMinutes: 30,
+      runbook: 'docs/runbooks/price-feed-stale.md',
+    };
+  }
+
+  return {
+    severity: 'info',
+    primaryChannel: 'slack',
+    primaryTarget: 'team-channel',
+    secondaryTarget: 'none',
+    ackWindowMinutes: 240,
+    runbook: 'docs/runbooks/price-anomaly.md',
+  };
+}

--- a/services/aggregator/tests/escalation-policy.test.ts
+++ b/services/aggregator/tests/escalation-policy.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { resolveEscalationRoute } from '../src/observability/escalation-policy';
+
+describe('Escalation policy', () => {
+  it('routes critical production failures to PagerDuty primary on-call and manager escalation', () => {
+    const route = resolveEscalationRoute({
+      type: 'source_down',
+      asset: 'XLM',
+      message: 'All sources down for XLM',
+    });
+
+    expect(route.severity).toBe('critical');
+    expect(route.primaryChannel).toBe('pagerduty');
+    expect(route.primaryTarget).toBe('primary-oncall');
+    expect(route.secondaryTarget).toBe('engineering-manager');
+    expect(route.ackWindowMinutes).toBe(15);
+  });
+
+  it('routes degraded but recoverable issues to Opsgenie and team lead escalation', () => {
+    const route = resolveEscalationRoute({
+      type: 'stale',
+      asset: 'BTC',
+      message: 'Price data stale for BTC',
+    });
+
+    expect(route.severity).toBe('warning');
+    expect(route.primaryChannel).toBe('opsgenie');
+    expect(route.primaryTarget).toBe('primary-oncall');
+    expect(route.secondaryTarget).toBe('team-lead');
+    expect(route.ackWindowMinutes).toBe(30);
+  });
+
+  it('keeps informational noise out of pages and only notifies the team channel', () => {
+    const route = resolveEscalationRoute({
+      type: 'deviation',
+      asset: 'ETH',
+      message: 'Minor single-source drift',
+    });
+
+    expect(route.severity).toBe('info');
+    expect(route.primaryChannel).toBe('slack');
+    expect(route.primaryTarget).toBe('team-channel');
+    expect(route.secondaryTarget).toBe('none');
+  });
+});


### PR DESCRIPTION
closes #398 
closes #399 
closes #400 
closes #401 



## Summary
- add severity-based escalation policy for production alerts
- wire PagerDuty + Opsgenie routing in the aggregator alert manager
- document rotation, handoff, shadowing, and test-page validation in the runbooks
- add a regression test covering escalation routes

## Verification
- 
- === Pre-push: Building backend services ===
Installing aggregator dependencies...

> @stellar-oracle/monorepo@1.0.0 prepare
> husky


up to date, audited 755 packages in 2s

135 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities

> @stellar-oracle/aggregator@1.0.0 build
> tsc


> @stellar-oracle/api@1.0.0 build
> tsc

=== Pre-push: All checks passed ===