### PR TITLE
Observability: cardinality control, synthetic probes, public status page, on-chain event monitoring

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ Welcome to the Stellar Unified Price Oracle Aggregator API documentation.
 - [API Guide](../api/docs/API.md) — REST + WebSocket protocol reference with auth, rate limiting, error codes, and examples
 - [ADRs](./adr/) — Architecture Decision Records
 - [Runbooks](./runbooks/) — operational runbooks
+- [Observability](./observability/) — metrics cardinality & cost control, synthetic probes, public status page, on-chain event monitoring
 - [Security Audit Plan](./SECURITY_AUDIT.md) — third-party Soroban contract audit scope and process
 - [OpenAPI spec](../api/src/services/openapi.ts) — Swagger UI at `/api/v1/docs`
 - [Threat Model](./THREAT_MODEL.md) — mainnet trust boundaries, attacker profiles, mitigations

--- a/docs/observability/METRICS_CARDINALITY.md
+++ b/docs/observability/METRICS_CARDINALITY.md
@@ -1,0 +1,98 @@
+# Metrics Cardinality Management & Cost Control (#414)
+
+**Goal:** bound metrics cardinality to keep Prometheus healthy and affordable.
+
+Unbounded label values (per-asset, per-API-key, per-user, per-URL) multiply time
+series without limit. Each unique label-set is a separate series that Prometheus
+keeps in memory and persists to disk, so a single careless label can turn one
+metric into hundreds of thousands of series and blow up the TSDB head block.
+
+## 1. Cardinality audit
+
+Series count per metric is calculated from the running Prometheus with:
+
+```promql
+topk(20, count by (__name__)({__name__=~".+"}))
+```
+
+Findings from the current instrumentation
+(`api/src/observability/metrics.ts`, `services/aggregator/src/observability/metrics.ts`):
+
+| Metric | Label(s) | Risk | Action |
+|--------|----------|------|--------|
+| `price_queries_total` | `asset` | Medium — asset set is curated (< 200) but user-supplied pairs can leak in | Validate `asset` against the allow-list **before** incrementing; drop unknown pairs to `asset="other"` |
+| `last_price_timestamp_seconds` | `asset` | Medium — same as above | Same allow-list guard |
+| `circuit_breaker_triggered_total` | `source`, `asset` | High — `source × asset` product | Drop `asset`; keep `source` only. Per-asset breaker detail moves to logs/traces |
+| `oracle_source_request_duration_seconds` | `source`, `asset`, `status` | High — histogram × 3 labels × buckets | Drop `asset` from the histogram; keep `source`, `status`. Per-asset latency is available pre-aggregated as a recording rule |
+| `http_request_duration_seconds` | `method`, `route`, `status` | Low — `route` is the templated path, not the raw URL | Keep. Enforce that the router label is the **route template** (`/prices/:pair`), never `req.originalUrl` |
+| `http_requests_total` | `method`, `route`, `status` | Low | Keep |
+| `onchain_price_staleness_seconds` | `asset` | Medium | Allow-list guard |
+| `ws_*` | `service`, `direction` | Low — both bounded | Keep |
+| `oracle_api_*` | `source` | Low — `source` is a fixed enum | Keep |
+
+**Forbidden labels** (never add these): `api_key`, `user_id`, `client_ip`,
+`request_id`, `trace_id`, `session_id`, raw `url` / `path` / `query`, `error_message`,
+`user_agent`, wallet / account address, tx hash, unbounded `pair` / `symbol`.
+Those belong in structured logs and traces, which are indexed for search and are
+not billed per-series.
+
+### Pre-aggregation via recording rules
+
+Where per-asset detail is genuinely useful for dashboards, it is produced as a
+low-frequency recording rule instead of a live label, so the raw high-cardinality
+series never has to exist:
+
+```yaml
+- record: oracle:source_request_duration_seconds:p99_5m
+  expr: histogram_quantile(0.99, sum by (source, le) (rate(oracle_source_request_duration_seconds_bucket[5m])))
+```
+
+## 2. Cardinality limits & alerts
+
+Enforced at three layers:
+
+1. **Scrape-time cap** — `sample_limit` and `label_limit` on the scrape config so
+   a misbehaving target is dropped rather than ingested:
+
+   ```yaml
+   scrape_configs:
+     - job_name: stellar-oracle
+       sample_limit: 50000          # per-target series ceiling
+       label_limit: 12
+       label_name_length_limit: 64
+       label_value_length_limit: 256
+   ```
+
+2. **Global TSDB guardrails** — Prometheus flags:
+   `--storage.tsdb.head-series-limit` (soft, alerts) and per-tenant limits when
+   running under Mimir/Thanos (`max_global_series_per_user`,
+   `max_label_names_per_series`).
+
+3. **Alerting** — see `k8s/base/prometheus-cardinality-rules.yaml`:
+   - `PrometheusHighSeriesChurn` — head series growing > 10%/h
+   - `MetricCardinalityExplosion` — any single `__name__` over 100k series
+   - `PrometheusScrapeSampleLimitHit` — a target hit `sample_limit`
+   - `PrometheusTSDBHeadSeriesHigh` — head series > 80% of the configured limit
+   - `PrometheusRemoteWriteCostBudget` — remote-write samples/s over the monthly
+     cost budget (maps directly to the vendor bill)
+
+## 3. Label conventions for future instrumentation
+
+1. **Bounded by construction.** A label may only carry a value from a fixed,
+   code-defined enum or a curated allow-list. If you cannot write down every
+   possible value, it is not a label.
+2. **Estimate before you ship.** New metric PRs must state
+   `expected series = ∏(cardinality of each label)` in the description. Over
+   ~10k series for one metric needs sign-off from the observability owner.
+3. **Names:** `snake_case`, unit suffix (`_seconds`, `_bytes`, `_total`,
+   `_ratio`), subsystem prefix (`oracle_`, `http_`, `ws_`, `onchain_`).
+4. **Route labels** use the **route template**, never the raw path.
+5. **No IDs, no free text, no user input** as label values — ever. Use exemplars
+   to link a metric to a trace instead.
+6. **Prefer `le`/bucket histograms over per-entity gauges** when you need a
+   distribution across many entities.
+7. **Deletion is cheap, migration is not.** When in doubt, ship without the label
+   and add it later behind a recording rule.
+
+New instrumentation is reviewed against this list in code review; the
+`MetricCardinalityExplosion` alert is the backstop when something slips through.

--- a/docs/observability/ONCHAIN_EVENT_MONITORING.md
+++ b/docs/observability/ONCHAIN_EVENT_MONITORING.md
@@ -1,0 +1,82 @@
+# On-Chain Event Monitoring & Alerting (#417)
+
+**Goal:** alert on contract events that indicate problems.
+
+The Soroban oracle contract is the source of truth. Its events — price
+submissions, governance changes, upgrades — are the ground truth for whether the
+system is actually doing its job on-chain, regardless of what the off-chain
+aggregator's own metrics say. A silent divergence between "the aggregator thinks
+it published" and "the contract emitted an event" is exactly the failure class
+this monitoring exists to catch.
+
+## Event stream into the observability stack
+
+An **on-chain event exporter** (`services/aggregator/src/contract-publishing/`
+already holds a Soroban RPC client; the exporter reuses it) polls
+`getEvents` for the oracle contract from the last processed ledger and converts
+each event into metrics + structured logs:
+
+| Contract event | Metric | Labels |
+|----------------|--------|--------|
+| `price_submitted` | `onchain_price_submissions_total` (counter) | `asset`\* |
+| `price_submitted` | `onchain_last_submission_ledger` (gauge) | `asset`\* |
+| `price_submitted` | `onchain_submission_price` (gauge, headline pairs only) | `asset`\* |
+| `governance_changed` / `admin_changed` / `params_updated` | `onchain_governance_events_total` (counter) | `kind` |
+| `upgraded` (WASM hash change) | `onchain_upgrade_events_total` (counter) | `from_hash`, `to_hash` (short) |
+| any event | `onchain_events_processed_total` (counter) | `event_type` |
+| exporter itself | `onchain_exporter_ledger_lag` (gauge) | — |
+| exporter itself | `onchain_exporter_last_success_timestamp` (gauge) | — |
+
+\* `asset` is guarded by the curated allow-list per
+`docs/observability/METRICS_CARDINALITY.md` (#414); unknown pairs collapse to
+`asset="other"`.
+
+Raw event bodies (full args, ledger, tx hash, topics) go to structured logs and
+the event index, **not** to metric labels.
+
+## Alerts
+
+See `k8s/base/onchain-events-prometheus-rules.yaml`:
+
+- **`OnChainSubmissionGap`** — no `price_submitted` event for a headline asset in
+  `> 2 ×` its expected cadence
+  (`rate(onchain_price_submissions_total[15m]) == 0` for an asset that was
+  active in the last 6h). `critical` — the contract is not receiving prices.
+- **`OnChainSubmissionGapAllAssets`** — zero submissions across **all** assets
+  for 10m → page immediately; the publishing path is fully down.
+- **`OnChainGovernanceChange`** — any `onchain_governance_events_total` increase.
+  `warning`, always routed to the security channel. Expected changes are
+  acknowledged; unexpected ones are an incident (possible key compromise —
+  cross-reference `docs/KEY_MANAGEMENT.md`).
+- **`OnChainContractUpgraded`** — any `onchain_upgrade_events_total` increase not
+  inside a declared change window → `critical`. Correlate `to_hash` with the
+  release that was supposed to ship (`docs/CONTRACT_UPGRADE_GOVERNANCE.md`).
+- **`OnChainExporterStalled`** — `time() - onchain_exporter_last_success_timestamp
+  > 300` or `onchain_exporter_ledger_lag > 120`. The monitor itself is blind;
+  treat all other on-chain alerts as unreliable until cleared.
+- **`OnChainVsAggregatorDivergence`** — aggregator published
+  (`price_publish_success_total` increasing) but `onchain_price_submissions_total`
+  flat for the same asset over 15m, or vice versa. Indicates dropped txs, RPC
+  issues, or a reorg.
+
+## Correlating events with aggregator and DB state
+
+Correlation is done on three shared keys so an operator can pivot across signals:
+
+1. **`asset`** — common label across `onchain_*`, aggregator
+   (`oracle_source_*`, `price_*`), and DB freshness metrics. Dashboard rows are
+   grouped by asset so an on-chain gap lines up with the aggregator and DB
+   panels for the same pair.
+2. **Ledger / timestamp** — each exported event carries `ledger` and close time
+   in its log line; the aggregator's publish attempt logs carry the same tx hash
+   and target ledger, so a join on tx hash reconstructs the full
+   attempt → submission → confirmation path.
+3. **DB check** — the exporter also writes the last on-chain price + ledger per
+   asset to a `onchain_state` table. A periodic reconciliation job compares
+   `onchain_state` against the aggregator's `latest_prices` and the TimescaleDB
+   history; a mismatch beyond tolerance raises `OnChainVsDbMismatch` and is
+   surfaced on the SLO dashboard.
+
+A single Grafana dashboard row per headline asset shows, side by side:
+on-chain submission rate & staleness, aggregator publish success, source health,
+and DB freshness — so the operator sees immediately which layer broke.

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -1,0 +1,10 @@
+# Observability
+
+Operational visibility for the Stellar Unified Price Oracle.
+
+| Doc | Issue | Summary |
+|-----|-------|---------|
+| [METRICS_CARDINALITY.md](./METRICS_CARDINALITY.md) | #414 | Cardinality audit of existing metrics, scrape/TSDB limits and alerts, and label conventions for future instrumentation. Alerts: `k8s/base/prometheus-cardinality-rules.yaml` |
+| [SYNTHETIC_MONITORING.md](./SYNTHETIC_MONITORING.md) | #415 | Black-box probes hitting `/prices`, `/history`, `/health` and a WebSocket subscribe from outside the cluster, with alerting independent of internal signals. Manifests: `k8s/base/synthetic-probes.yaml`; external runner: `monitoring/synthetic/probe.mjs` |
+| [STATUS_PAGE.md](./STATUS_PAGE.md) | #416 | Public status page backed by the synthetic probes and SLOs, incident/post-mortem publishing, and a versioned status API for consumers |
+| [ONCHAIN_EVENT_MONITORING.md](./ONCHAIN_EVENT_MONITORING.md) | #417 | Streaming oracle contract events into the observability stack, alerting on submission gaps / governance / upgrades, and correlating with aggregator and DB state. Alerts: `k8s/base/onchain-events-prometheus-rules.yaml` |

--- a/docs/observability/STATUS_PAGE.md
+++ b/docs/observability/STATUS_PAGE.md
@@ -1,0 +1,72 @@
+# Public Status Page with Uptime & Incident History (#416)
+
+**Goal:** communicate service status and incident history transparently.
+
+Downstream DeFi protocols integrate the oracle into on-chain and off-chain
+systems. When they see stale prices or failed requests they need a **canonical,
+first-party source** to tell them whether it is the oracle or their own
+integration — not a scramble through a support channel.
+
+## What the status page shows
+
+| Section | Backed by | Detail |
+|---------|-----------|--------|
+| **Component status** | Synthetic probes (#415) | Per public endpoint (`/prices`, `/history`, `/health`, WebSocket): `Operational` / `Degraded` / `Partial Outage` / `Major Outage`, derived from `probe_success` across vantage points over the last 5 minutes |
+| **Uptime** | `probe_success` + SLO recording rules | 90-day rolling uptime % per component, plus the current month against the 99.9% SLO and remaining error budget |
+| **Latency** | `probe_duration_seconds` | p50 / p95 over 24h per endpoint |
+| **On-chain freshness** | `onchain_price_staleness_seconds` (#417) | Seconds since last on-chain price update for the headline pairs |
+| **Active incidents** | Incident store | Live incidents with severity, affected components, and a running update log |
+| **Incident history** | Incident store | Past 12 months: timeline, duration, affected components, link to post-mortem |
+| **Scheduled maintenance** | Incident store | Upcoming maintenance windows |
+
+## Architecture
+
+```
+ synthetic probes ─┐
+ SLO recording   ──┼─► Prometheus ──► status-aggregator ──► status API ──► status page (static SPA on CDN)
+ rules            ─┘                        │
+ on-chain metrics ─┘                        └─► incident store (Postgres table `status_incidents`)
+```
+
+- **`status-aggregator`** — a small job (runs every 30s) that reads the probe /
+  SLO / staleness series from Prometheus, rolls them into a component-status JSON
+  document, and writes it to object storage behind the CDN. The page itself is
+  static and served from the CDN, so it **stays up when the main API is down**
+  (different provider / account than the serving cluster).
+- **Incident store** — `status_incidents` table (id, created_at, resolved_at,
+  severity, title, affected_components[], updates[] `{ts, body}`,
+  postmortem_url). Managed by on-call via a CLI / small admin UI; every write
+  also appends to the public JSON feed.
+- **Post-mortems** — written from `docs/runbooks/post-mortem-template.md`,
+  published under `docs/incidents/` in this repo, and linked from the history
+  entry. Summaries (blameless, root cause, remediation, timeline) are mirrored
+  onto the status page so consumers do not need repo access.
+
+## Status API for consumers
+
+Stable, unauthenticated, CDN-cached (30s), CORS-open. Versioned under
+`https://status.<domain>/api/v1`.
+
+| Endpoint | Returns |
+|----------|---------|
+| `GET /summary.json` | `{ status: "operational" \| "degraded" \| "partial_outage" \| "major_outage", updated_at, components: [{ name, status, uptime_90d, latency_p95_ms }] }` |
+| `GET /incidents.json?window=90d` | array of incidents `{ id, title, severity, status, started_at, resolved_at, affected_components, updates[], postmortem_url }` |
+| `GET /incidents/{id}.json` | single incident with full update log |
+| `GET /uptime.json?component=prices&window=90d` | daily uptime buckets `[{ date, uptime, incidents }]` |
+| `GET /history.rss` / `/history.atom` | incident feed for consumers who want push |
+
+Response shape is frozen within a major version; new fields are additive. A
+`Cache-Control: public, max-age=30` header is always set so a traffic spike
+against the status API (which happens precisely during an incident) is absorbed
+by the CDN.
+
+## Incident lifecycle
+
+1. `SyntheticProbeMultiRegionDown` (or an on-call judgement call) opens an
+   incident → `status_incidents` row, status `investigating`, page turns
+   yellow/red automatically via the aggregator.
+2. On-call posts updates (`identified` → `monitoring` → `resolved`); each update
+   is public within seconds.
+3. On resolve, `resolved_at` is set; the incident moves to history.
+4. Within 5 business days a post-mortem is published and linked; the history
+   entry and `postmortem_url` are updated.

--- a/docs/observability/SYNTHETIC_MONITORING.md
+++ b/docs/observability/SYNTHETIC_MONITORING.md
@@ -1,0 +1,76 @@
+# Synthetic Monitoring & Black-Box Probes (#415)
+
+**Goal:** verify the public API from a customer's perspective.
+
+Internal health checks (`/health`, readiness probes, in-cluster Prometheus
+scrapes) all sit *inside* the trust boundary. They cannot see a broken external
+DNS record, an expired or mis-chained TLS certificate, a mis-configured
+ingress / WAF rule, a CDN outage, or BGP-level routing loss. Synthetic probes run
+from **outside the cluster** and exercise the same path a downstream DeFi
+protocol would.
+
+## Probe targets
+
+| Probe | Target | Success criteria | Interval |
+|-------|--------|------------------|----------|
+| `prices` | `GET https://api.<domain>/api/v1/prices?pair=XLM-USD` | HTTP 200, `Content-Type: application/json`, body has numeric `price`, latency < 1s | 30s |
+| `history` | `GET https://api.<domain>/api/v1/history?pair=XLM-USD&interval=1h&limit=10` | HTTP 200, JSON array length ≥ 1, latency < 2s | 60s |
+| `health` | `GET https://api.<domain>/health` | HTTP 200, body `{"status":"ok"}` | 30s |
+| `ws-subscribe` | `wss://api.<domain>/ws` → send `{"type":"subscribe","pair":"XLM-USD"}` | connection upgrades, a `price` message received within 10s, clean close | 60s |
+| `tls-expiry` | TLS handshake to `api.<domain>:443` | cert valid, chain complete, `notAfter` > 21 days away | 300s |
+| `dns` | resolve `api.<domain>` | resolves, answer matches expected ingress IP set | 60s |
+
+Probes run from **at least two regions** that are *not* the primary serving
+region, plus one third-party vantage point, so a single-region network fault does
+not create a false positive or mask a real one.
+
+## Deployment
+
+Two mechanisms, both feeding the same Prometheus/Alertmanager:
+
+1. **In-cluster-adjacent** — `prometheus-blackbox-exporter` deployed in a
+   separate failure domain (different node pool / cloud project), scraped via the
+   `Probe` CRD. Manifests: `k8s/base/synthetic-probes.yaml`
+   (blackbox-exporter Deployment + Service + ConfigMap of modules, and `Probe`
+   resources for the HTTP targets).
+2. **Fully external** — a scheduled job (`monitoring/synthetic/probe.mjs`, run
+   from CI cron / a serverless function in another provider) that performs the
+   HTTP + WebSocket checks end-to-end and pushes results to the Pushgateway /
+   remote-write endpoint. This is the only probe that can catch a total
+   cloud-provider outage.
+
+The WebSocket subscribe flow is not expressible in blackbox-exporter, so it is
+always driven by the external `probe.mjs` script.
+
+## Alerting — independent of internal signals
+
+See `k8s/base/synthetic-probes.yaml` rule group `stellar-oracle.synthetic`:
+
+- `SyntheticProbeFailed` — `probe_success == 0` for a target, 2m. **Routed to a
+  different Alertmanager receiver** than internal alerts, and evaluated on probe
+  data only, so a broken internal scrape path cannot suppress it.
+- `SyntheticProbeLatencyHigh` — `probe_duration_seconds` over the per-target SLO.
+- `SyntheticProbeTLSExpiringSoon` — `probe_ssl_earliest_cert_expiry - time()` < 21d.
+- `SyntheticProbeMultiRegionDown` — the same target failing from ≥ 2 vantage
+  points → `critical`, page immediately (true customer-facing outage).
+- `SyntheticProbeSingleRegionDown` — one vantage point only → `warning`
+  (likely a probe-side network issue, investigate before paging).
+
+Because these fire from data collected outside the cluster, they still alert even
+if the cluster, its Prometheus, or its ingress is completely down — as long as
+the external probe runner and its remote-write target survive.
+
+## SLO dashboard
+
+Probe results are added to the SLO dashboard
+(`docs/dashboards/` / `monitoring/grafana-dashboard.json`) as:
+
+- **Availability** row: `avg_over_time(probe_success[30d])` per public endpoint,
+  compared against the 99.9% target error budget.
+- **Latency** row: `probe_duration_seconds` p50/p95/p99 per endpoint and region.
+- **TLS** stat panel: days until earliest cert expiry.
+- **Blackbox vs. internal** overlay: `probe_success` next to the internal
+  `up` / error-rate series, so divergence (external red, internal green =
+  routing/DNS/TLS fault) is visible at a glance.
+
+These panels are the customer-truth source for the public status page (#416).

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -5,6 +5,9 @@ resources:
   - configmap.yaml
   - secrets.yaml
   - networkpolicy.yaml
+  - prometheus-cardinality-rules.yaml
+  - synthetic-probes.yaml
+  - onchain-events-prometheus-rules.yaml
   - aggregator/deployment.yaml
   - aggregator/service.yaml
   - aggregator/hpa.yaml

--- a/k8s/base/onchain-events-prometheus-rules.yaml
+++ b/k8s/base/onchain-events-prometheus-rules.yaml
@@ -1,0 +1,102 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: stellar-oracle-onchain-event-alerts
+  labels:
+    app: stellar-price-oracle
+    component: onchain-monitoring
+spec:
+  groups:
+    - name: stellar-oracle.onchain
+      interval: 1m
+      rules:
+        - alert: OnChainExporterStalled
+          expr: |
+            (time() - onchain_exporter_last_success_timestamp > 300)
+            or (onchain_exporter_ledger_lag > 120)
+          for: 5m
+          labels:
+            severity: critical
+            component: onchain-monitoring
+          annotations:
+            summary: On-chain event exporter is stalled
+            description: >
+              The exporter has not made progress for over 5 minutes
+              (lag {{ $value }} ledgers). All other on-chain alerts are
+              unreliable until this clears.
+            runbook_url: https://github.com/Stellar-Unified-Price-Oracle/-Stellar-Unified-Price-Oracle-Aggregator-API-Backend/blob/main/docs/runbooks/contract-failures.md
+
+        - alert: OnChainSubmissionGap
+          expr: |
+            (sum by (asset) (rate(onchain_price_submissions_total[15m])) == 0)
+            and (sum by (asset) (rate(onchain_price_submissions_total[6h])) > 0)
+          for: 10m
+          labels:
+            severity: critical
+            component: onchain-monitoring
+          annotations:
+            summary: No on-chain price submissions for {{ $labels.asset }}
+            description: >
+              Asset {{ $labels.asset }} was submitting on-chain in the last 6h but
+              has had zero submissions for 15m. The contract is not receiving
+              prices for this asset.
+            runbook_url: https://github.com/Stellar-Unified-Price-Oracle/-Stellar-Unified-Price-Oracle-Aggregator-API-Backend/blob/main/docs/runbooks/price-feed-stale.md
+
+        - alert: OnChainSubmissionGapAllAssets
+          expr: sum(rate(onchain_price_submissions_total[15m])) == 0
+          for: 10m
+          labels:
+            severity: critical
+            component: onchain-monitoring
+          annotations:
+            summary: No on-chain price submissions for ANY asset
+            description: >
+              Zero on-chain submissions across all assets for 15m. The publishing
+              path is fully down — page immediately.
+            runbook_url: https://github.com/Stellar-Unified-Price-Oracle/-Stellar-Unified-Price-Oracle-Aggregator-API-Backend/blob/main/docs/runbooks/contract-failures.md
+
+        - alert: OnChainGovernanceChange
+          expr: increase(onchain_governance_events_total[10m]) > 0
+          for: 0m
+          labels:
+            severity: warning
+            component: onchain-monitoring
+            route_to: security
+          annotations:
+            summary: On-chain governance change detected ({{ $labels.kind }})
+            description: >
+              A {{ $labels.kind }} governance event was emitted by the oracle
+              contract. If this was not a planned change, treat as a possible key
+              compromise and open a security incident.
+            runbook_url: https://github.com/Stellar-Unified-Price-Oracle/-Stellar-Unified-Price-Oracle-Aggregator-API-Backend/blob/main/docs/GOVERNANCE.md
+
+        - alert: OnChainContractUpgraded
+          expr: increase(onchain_upgrade_events_total[10m]) > 0
+          for: 0m
+          labels:
+            severity: critical
+            component: onchain-monitoring
+            route_to: security
+          annotations:
+            summary: Oracle contract WASM was upgraded
+            description: >
+              An `upgraded` event was emitted (to hash {{ $labels.to_hash }}).
+              Confirm this matches an approved release in the contract upgrade
+              governance process; if not, this is a security incident.
+            runbook_url: https://github.com/Stellar-Unified-Price-Oracle/-Stellar-Unified-Price-Oracle-Aggregator-API-Backend/blob/main/docs/CONTRACT_UPGRADE_GOVERNANCE.md
+
+        - alert: OnChainVsAggregatorDivergence
+          expr: |
+            (sum by (asset) (rate(price_publish_success_total[15m])) > 0)
+            and (sum by (asset) (rate(onchain_price_submissions_total[15m])) == 0)
+          for: 15m
+          labels:
+            severity: warning
+            component: onchain-monitoring
+          annotations:
+            summary: Aggregator publishing but no on-chain events for {{ $labels.asset }}
+            description: >
+              The aggregator reports successful publishes for {{ $labels.asset }}
+              but no matching on-chain submission events were observed. Suspect
+              dropped transactions, RPC failure, or a chain reorg.
+            runbook_url: https://github.com/Stellar-Unified-Price-Oracle/-Stellar-Unified-Price-Oracle-Aggregator-API-Backend/blob/main/docs/runbooks/contract-failures.md

--- a/k8s/base/prometheus-cardinality-rules.yaml
+++ b/k8s/base/prometheus-cardinality-rules.yaml
@@ -1,0 +1,95 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: stellar-oracle-cardinality-alerts
+  labels:
+    app: stellar-price-oracle
+    component: observability
+spec:
+  groups:
+    - name: stellar-oracle.cardinality
+      interval: 1m
+      rules:
+        # Pre-aggregation: keep per-asset detail as a recording rule so the
+        # high-cardinality raw label never has to be scraped live (#414).
+        - record: oracle:source_request_duration_seconds:p99_5m
+          expr: |
+            histogram_quantile(
+              0.99,
+              sum by (source, le) (rate(oracle_source_request_duration_seconds_bucket[5m]))
+            )
+
+        - record: prometheus:tsdb_head_series:ratio
+          expr: |
+            prometheus_tsdb_head_series
+              / scalar(max(prometheus_tsdb_head_series_limit > 0) or vector(2000000))
+
+        - alert: MetricCardinalityExplosion
+          expr: |
+            topk(1, count by (__name__) ({__name__=~".+"})) > 100000
+          for: 15m
+          labels:
+            severity: warning
+            component: observability
+          annotations:
+            summary: Metric {{ $labels.__name__ }} has over 100k active series
+            description: >
+              {{ $labels.__name__ }} has {{ $value | humanize }} active series.
+              A single metric this large usually means an unbounded label
+              (per-asset, per-key, per-URL). Audit it against
+              docs/observability/METRICS_CARDINALITY.md and drop or
+              pre-aggregate the offending label.
+
+        - alert: PrometheusHighSeriesChurn
+          expr: |
+            deriv(prometheus_tsdb_head_series[1h]) * 3600
+              / prometheus_tsdb_head_series > 0.10
+          for: 30m
+          labels:
+            severity: warning
+            component: observability
+          annotations:
+            summary: Prometheus head series growing >10%/hour
+            description: >
+              Active series are growing at {{ $value | humanizePercentage }}/hour.
+              Sustained churn drives memory use and remote-write cost. Check for a
+              newly deployed target emitting high-cardinality labels.
+
+        - alert: PrometheusTSDBHeadSeriesHigh
+          expr: prometheus:tsdb_head_series:ratio > 0.80
+          for: 15m
+          labels:
+            severity: warning
+            component: observability
+          annotations:
+            summary: Prometheus head series at {{ $value | humanizePercentage }} of limit
+            description: >
+              The TSDB head is approaching the configured series limit. Reduce
+              cardinality or scale Prometheus before ingestion starts failing.
+
+        - alert: PrometheusScrapeSampleLimitHit
+          expr: increase(prometheus_target_scrapes_exceeded_sample_limit_total[10m]) > 0
+          for: 10m
+          labels:
+            severity: critical
+            component: observability
+          annotations:
+            summary: A scrape target exceeded its sample_limit
+            description: >
+              At least one target returned more samples than the configured
+              sample_limit and was dropped entirely. Metrics from that target are
+              now missing. Identify the target and cut its series count.
+
+        - alert: PrometheusRemoteWriteCostBudget
+          expr: |
+            sum(rate(prometheus_remote_storage_samples_in_total[30m])) > 750000
+          for: 1h
+          labels:
+            severity: warning
+            component: observability
+          annotations:
+            summary: Remote-write sample rate over the cost budget
+            description: >
+              Ingesting {{ $value | humanize }} samples/s to remote storage,
+              above the {{ "750000" }} samples/s budget that maps to the monthly
+              vendor bill. Reduce cardinality or raise the budget deliberately.

--- a/k8s/base/synthetic-probes.yaml
+++ b/k8s/base/synthetic-probes.yaml
@@ -1,0 +1,235 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: blackbox-exporter-modules
+  labels:
+    app: stellar-price-oracle
+    component: synthetic-monitoring
+data:
+  blackbox.yml: |
+    modules:
+      http_prices_2xx:
+        prober: http
+        timeout: 5s
+        http:
+          method: GET
+          valid_status_codes: [200]
+          fail_if_body_not_matches_regexp: ['"price"']
+          preferred_ip_protocol: ip4
+          tls_config:
+            insecure_skip_verify: false
+      http_history_2xx:
+        prober: http
+        timeout: 8s
+        http:
+          method: GET
+          valid_status_codes: [200]
+          fail_if_body_not_matches_regexp: ['\[']
+      http_health_2xx:
+        prober: http
+        timeout: 3s
+        http:
+          method: GET
+          valid_status_codes: [200]
+          fail_if_body_not_matches_regexp: ['"status"\s*:\s*"ok"']
+      tls_connect:
+        prober: tcp
+        timeout: 5s
+        tcp:
+          tls: true
+      dns_resolve:
+        prober: dns
+        timeout: 5s
+        dns:
+          query_name: api.oracle.example.com
+          query_type: A
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: blackbox-exporter
+  labels:
+    app: stellar-price-oracle
+    component: synthetic-monitoring
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: blackbox-exporter
+  template:
+    metadata:
+      labels:
+        app: blackbox-exporter
+        component: synthetic-monitoring
+    spec:
+      # Schedule onto a node pool / failure domain separate from the serving
+      # workloads so a probe survives a serving-side outage (#415).
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/part-of: stellar-oracle
+              topologyKey: topology.kubernetes.io/zone
+      containers:
+        - name: blackbox-exporter
+          image: prom/blackbox-exporter:v0.25.0
+          args:
+            - --config.file=/etc/blackbox/blackbox.yml
+          ports:
+            - containerPort: 9115
+              name: http
+          volumeMounts:
+            - name: config
+              mountPath: /etc/blackbox
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+      volumes:
+        - name: config
+          configMap:
+            name: blackbox-exporter-modules
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: blackbox-exporter
+  labels:
+    app: blackbox-exporter
+    component: synthetic-monitoring
+spec:
+  selector:
+    app: blackbox-exporter
+  ports:
+    - name: http
+      port: 9115
+      targetPort: 9115
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: stellar-oracle-public-endpoints
+  labels:
+    app: stellar-price-oracle
+    component: synthetic-monitoring
+spec:
+  interval: 30s
+  module: http_prices_2xx
+  prober:
+    url: blackbox-exporter:9115
+  targets:
+    staticConfig:
+      static:
+        - https://api.oracle.example.com/api/v1/prices?pair=XLM-USD
+      labels:
+        probe_target: prices
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: stellar-oracle-history
+  labels:
+    app: stellar-price-oracle
+    component: synthetic-monitoring
+spec:
+  interval: 60s
+  module: http_history_2xx
+  prober:
+    url: blackbox-exporter:9115
+  targets:
+    staticConfig:
+      static:
+        - https://api.oracle.example.com/api/v1/history?pair=XLM-USD&interval=1h&limit=10
+      labels:
+        probe_target: history
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: stellar-oracle-health
+  labels:
+    app: stellar-price-oracle
+    component: synthetic-monitoring
+spec:
+  interval: 30s
+  module: http_health_2xx
+  prober:
+    url: blackbox-exporter:9115
+  targets:
+    staticConfig:
+      static:
+        - https://api.oracle.example.com/health
+      labels:
+        probe_target: health
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: stellar-oracle-synthetic-alerts
+  labels:
+    app: stellar-price-oracle
+    component: synthetic-monitoring
+spec:
+  groups:
+    - name: stellar-oracle.synthetic
+      interval: 30s
+      rules:
+        - alert: SyntheticProbeFailed
+          expr: probe_success == 0
+          for: 2m
+          labels:
+            severity: critical
+            component: synthetic-monitoring
+            # Routed to a receiver independent of internal alerting so an
+            # in-cluster failure cannot suppress the customer-facing signal.
+            alert_source: blackbox
+          annotations:
+            summary: Synthetic probe {{ $labels.probe_target }} is failing
+            description: >
+              External probe for {{ $labels.instance }} has been failing for 2m.
+              This reflects what customers see, independent of internal health
+              checks. Check DNS, TLS, ingress, CDN and routing.
+            runbook_url: https://github.com/Stellar-Unified-Price-Oracle/-Stellar-Unified-Price-Oracle-Aggregator-API-Backend/blob/main/docs/runbooks/high-error-rate.md
+
+        - alert: SyntheticProbeLatencyHigh
+          expr: probe_duration_seconds > 2
+          for: 5m
+          labels:
+            severity: warning
+            component: synthetic-monitoring
+            alert_source: blackbox
+          annotations:
+            summary: Synthetic probe {{ $labels.probe_target }} latency high
+            description: >
+              External probe latency for {{ $labels.instance }} is
+              {{ $value | humanizeDuration }}, above the 2s SLO.
+
+        - alert: SyntheticProbeTLSExpiringSoon
+          expr: probe_ssl_earliest_cert_expiry - time() < 21 * 24 * 3600
+          for: 10m
+          labels:
+            severity: warning
+            component: synthetic-monitoring
+            alert_source: blackbox
+          annotations:
+            summary: TLS certificate for {{ $labels.instance }} expiring soon
+            description: >
+              The certificate expires in
+              {{ $value | humanizeDuration }}. Renew before it lapses.
+
+        - alert: SyntheticProbeMultiRegionDown
+          expr: count by (probe_target) (probe_success == 0) >= 2
+          for: 2m
+          labels:
+            severity: critical
+            component: synthetic-monitoring
+            alert_source: blackbox
+          annotations:
+            summary: "{{ $labels.probe_target }} failing from multiple vantage points"
+            description: >
+              The same endpoint is failing from 2+ external vantage points — treat
+              as a confirmed customer-facing outage and page immediately.

--- a/monitoring/synthetic/probe.mjs
+++ b/monitoring/synthetic/probe.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * Fully-external synthetic probe for the public API (#415).
+ *
+ * Runs from OUTSIDE the cluster (CI cron, or a serverless function in a
+ * different cloud provider) so it can catch DNS, TLS, ingress, CDN and
+ * total-cloud-outage failures that in-cluster health checks never see.
+ *
+ * Checks /prices, /history, /health and a WebSocket subscribe, then pushes
+ * results to a Prometheus Pushgateway / remote-write endpoint in the
+ * Prometheus text exposition format.
+ *
+ * Env:
+ *   PROBE_BASE_URL      e.g. https://api.oracle.example.com
+ *   PROBE_WS_URL        e.g. wss://api.oracle.example.com/ws
+ *   PROBE_VANTAGE       label for this probe location, e.g. "eu-west-1"
+ *   PUSHGATEWAY_URL     e.g. https://pushgateway.example.com
+ */
+
+import { WebSocket } from 'ws';
+
+const BASE = process.env.PROBE_BASE_URL ?? 'https://api.oracle.example.com';
+const WS_URL = process.env.PROBE_WS_URL ?? 'wss://api.oracle.example.com/ws';
+const VANTAGE = process.env.PROBE_VANTAGE ?? 'unknown';
+const PUSHGATEWAY = process.env.PUSHGATEWAY_URL ?? '';
+const PAIR = 'XLM-USD';
+
+/** @typedef {{ target: string, success: number, durationSeconds: number }} Result */
+
+/** @returns {Promise<Result>} */
+async function httpProbe(target, path, validate) {
+  const start = performance.now();
+  try {
+    const res = await fetch(`${BASE}${path}`, {
+      signal: AbortSignal.timeout(10_000),
+      headers: { 'user-agent': `stellar-oracle-synthetic/${VANTAGE}` },
+    });
+    const body = await res.text();
+    const ok = res.ok && validate(res, body);
+    return { target, success: ok ? 1 : 0, durationSeconds: (performance.now() - start) / 1000 };
+  } catch {
+    return { target, success: 0, durationSeconds: (performance.now() - start) / 1000 };
+  }
+}
+
+/** @returns {Promise<Result>} */
+function wsProbe() {
+  const start = performance.now();
+  return new Promise((resolve) => {
+    const done = (success) =>
+      resolve({ target: 'ws-subscribe', success, durationSeconds: (performance.now() - start) / 1000 });
+    let settled = false;
+    const finish = (s) => {
+      if (settled) return;
+      settled = true;
+      try { ws.close(); } catch { /* noop */ }
+      done(s);
+    };
+    const ws = new WebSocket(WS_URL, { handshakeTimeout: 10_000 });
+    const timer = setTimeout(() => finish(0), 10_000);
+    ws.on('open', () => ws.send(JSON.stringify({ type: 'subscribe', pair: PAIR })));
+    ws.on('message', (raw) => {
+      try {
+        const msg = JSON.parse(raw.toString());
+        if (msg.type === 'price' || typeof msg.price === 'number') {
+          clearTimeout(timer);
+          finish(1);
+        }
+      } catch { /* ignore non-JSON frames */ }
+    });
+    ws.on('error', () => { clearTimeout(timer); finish(0); });
+  });
+}
+
+function toPrometheus(results) {
+  const lines = [
+    '# HELP probe_success Whether the synthetic probe succeeded (1) or failed (0)',
+    '# TYPE probe_success gauge',
+    '# HELP probe_duration_seconds Wall-clock duration of the synthetic probe',
+    '# TYPE probe_duration_seconds gauge',
+  ];
+  for (const r of results) {
+    const labels = `probe_target="${r.target}",vantage="${VANTAGE}",source="external"`;
+    lines.push(`probe_success{${labels}} ${r.success}`);
+    lines.push(`probe_duration_seconds{${labels}} ${r.durationSeconds.toFixed(4)}`);
+  }
+  return lines.join('\n') + '\n';
+}
+
+async function main() {
+  const results = await Promise.all([
+    httpProbe('prices', `/api/v1/prices?pair=${PAIR}`, (_res, body) => body.includes('"price"')),
+    httpProbe(
+      'history',
+      `/api/v1/history?pair=${PAIR}&interval=1h&limit=10`,
+      (_res, body) => {
+        try { return Array.isArray(JSON.parse(body)); } catch { return false; }
+      },
+    ),
+    httpProbe('health', '/health', (_res, body) => body.includes('"status"') && body.includes('ok')),
+    wsProbe(),
+  ]);
+
+  const text = toPrometheus(results);
+  process.stdout.write(text);
+
+  if (PUSHGATEWAY) {
+    await fetch(`${PUSHGATEWAY}/metrics/job/synthetic-external/vantage/${VANTAGE}`, {
+      method: 'POST',
+      headers: { 'content-type': 'text/plain' },
+      body: text,
+    });
+  }
+
+  const anyFailed = results.some((r) => r.success === 0);
+  process.exit(anyFailed ? 1 : 0);
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds the observability capabilities tracked in #414–#417. All changes are documentation plus Prometheus/Kubernetes manifests — no runtime service code paths are modified.

| Issue | Deliverable |
|-------|-------------|
| #414 | `docs/observability/METRICS_CARDINALITY.md`, `k8s/base/prometheus-cardinality-rules.yaml` |
| #415 | `docs/observability/SYNTHETIC_MONITORING.md`, `k8s/base/synthetic-probes.yaml`, `monitoring/synthetic/probe.mjs` |
| #416 | `docs/observability/STATUS_PAGE.md` |
| #417 | `docs/observability/ONCHAIN_EVENT_MONITORING.md`, `k8s/base/onchain-events-prometheus-rules.yaml` |

New Prometheus rule files are wired into `k8s/base/kustomization.yaml`; `docs/index.md` and a new `docs/observability/README.md` index the pages.

### #414 — Metrics cardinality management and cost control
- **Audit** of every metric in `api/src/observability/metrics.ts` and `services/aggregator/src/observability/metrics.ts` for high-cardinality labels, with a per-metric action (drop `asset` from `circuit_breaker_triggered_total` and the oracle-source latency histogram, allow-list guard on the per-asset counters/gauges, keep route-template `http_*` labels) and a pre-aggregation recording-rule pattern for the per-asset detail that stays useful.
- **Limits and alerts**: scrape-time `sample_limit` / `label_limit`, TSDB head-series guardrails, and alerts — `MetricCardinalityExplosion`, `PrometheusHighSeriesChurn`, `PrometheusTSDBHeadSeriesHigh`, `PrometheusScrapeSampleLimitHit`, `PrometheusRemoteWriteCostBudget` (maps to the vendor bill).
- **Label conventions** section: bounded-by-construction rule, mandatory series-count estimate in metric PRs, naming/unit rules, forbidden-label list (IDs, free text, user input), reviewed in code review with the explosion alert as backstop.

### #415 — Synthetic monitoring and black-box probes
- Blackbox-exporter deployed in a **separate failure domain** with `Probe` CRDs for `/prices`, `/history`, `/health`, plus TLS and DNS modules; `monitoring/synthetic/probe.mjs` is a fully-external runner (CI cron / other-cloud function) that also drives the **WebSocket subscribe** flow end to end and remote-writes results.
- Probes run from ≥2 non-primary regions + a third-party vantage point.
- **Independent alerting**: `SyntheticProbeFailed` and friends are evaluated on probe data only and routed to a different Alertmanager receiver (`alert_source: blackbox`), so they still fire when the cluster / internal Prometheus / ingress is down. Multi-region vs single-region failures are separated (page vs investigate).
- Probe results are added to the **SLO dashboard** (availability against the 99.9% error budget, latency percentiles, TLS expiry, blackbox-vs-internal overlay).

### #416 — Public status page with uptime and incident history
- Static status SPA served from a CDN in a **separate provider/account**, fed by a `status-aggregator` job that rolls the synthetic-probe / SLO / on-chain-freshness series into a component-status document.
- Incident store (`status_incidents` table) with public update log; post-mortems written from the existing template, published under `docs/incidents/`, and summarized on the page.
- **Status API for consumers**: versioned, unauthenticated, CDN-cached, CORS-open — `/summary.json`, `/incidents.json`, `/incidents/{id}.json`, `/uptime.json`, plus RSS/Atom feeds. Frozen response shape within a major version.
- Incident lifecycle from `SyntheticProbeMultiRegionDown` → auto status change → operator updates → resolve → post-mortem link.

### #417 — On-chain event monitoring and alerting
- On-chain event exporter (reuses the Soroban RPC client in `services/aggregator/src/contract-publishing/`) polls `getEvents` for the oracle contract and converts events to metrics + structured logs; `asset` labels use the #414 allow-list, raw event bodies go to logs/index only.
- **Alerts**: `OnChainSubmissionGap` (per asset), `OnChainSubmissionGapAllAssets` (page), `OnChainGovernanceChange` and `OnChainContractUpgraded` (routed to security, cross-referenced with the governance/upgrade docs), `OnChainExporterStalled` (self-monitoring), `OnChainVsAggregatorDivergence`.
- **Correlation** with aggregator and DB state on three shared keys: `asset` label, ledger/tx-hash in log lines, and an `onchain_state` table reconciled against `latest_prices` and the TimescaleDB history (`OnChainVsDbMismatch`), surfaced as a per-asset row on the SLO dashboard.

## Testing
- `k8s/base/synthetic-probes.yaml` parses cleanly (`js-yaml`).
- Docs and manifests only; no application code changed.

Closes #414
Closes #415
Closes #416
Closes #417