### PR TITLE
Observability & data: cost dashboard, history gap detection, cross-region tracing, price validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,19 @@ jobs:
       - name: Verify cost analysis report
         run: npm run cost:check
 
+  price-correctness:
+    name: Price correctness validation suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Validate aggregated price correctness
+        run: npm run validate:prices
+
   aggregator:
     name: Aggregator service build
     runs-on: ubuntu-latest

--- a/.github/workflows/history-gap-detection.yml
+++ b/.github/workflows/history-gap-detection.yml
@@ -1,0 +1,63 @@
+name: History gap detection
+
+# Issue #421 — keep the price_history dataset continuous and complete.
+# Runs hourly and on demand; fails (alerts) when a gap exceeds the threshold.
+
+on:
+  schedule:
+    - cron: '17 * * * *'
+  workflow_dispatch:
+    inputs:
+      since:
+        description: 'ISO date to scan from (default: last 7 days)'
+        required: false
+
+env:
+  NODE_VERSION: '20'
+  HISTORY_EXPECTED_INTERVAL_SEC: '60'
+  HISTORY_GAP_ALERT_SEC: '900'
+
+jobs:
+  detect-gaps:
+    name: Detect price_history gaps
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: api
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: api/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Detect gaps
+        env:
+          DATABASE_URL: ${{ secrets.HISTORY_DATABASE_URL }}
+        run: npm run history:gaps -- --json ${{ github.event.inputs.since && format('--since {0}', github.event.inputs.since) || '' }}
+
+      - name: Alert on threshold breach
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `price_history gap detected (${new Date().toISOString().slice(0, 10)})`,
+              labels: ['data', 'alert'],
+              body: [
+                'The scheduled history gap detector found a gap exceeding',
+                `\`HISTORY_GAP_ALERT_SEC=${process.env.HISTORY_GAP_ALERT_SEC}\`.`,
+                '',
+                `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+                '',
+                'Backfill with `npm run history:backfill -- --asset <ASSET> --from <startTs> --to <endTs>`',
+                'then re-run this workflow to confirm the gap is closed.',
+              ].join('\n'),
+            });

--- a/api/package.json
+++ b/api/package.json
@@ -17,6 +17,8 @@
     "archive:run": "tsx scripts/archive.ts run",
     "archive:dry-run": "tsx scripts/archive.ts run --dry-run",
     "archive:restore": "tsx scripts/archive.ts restore",
+    "history:gaps": "tsx scripts/detect-history-gaps.ts",
+    "history:backfill": "tsx scripts/backfill-history.ts",
     "generate:openapi": "tsx scripts/export-openapi.ts",
     "docs:generate": "typedoc --options typedoc.json",
     "pact:consumer": "jest --testPathPattern=pact/consumer --testTimeout=30000",

--- a/api/scripts/backfill-history.ts
+++ b/api/scripts/backfill-history.ts
@@ -1,0 +1,130 @@
+#!/usr/bin/env tsx
+/**
+ * Backfill `price_history` from source snapshot files (issue #421).
+ *
+ * Pairs with `detect-history-gaps.ts`: once a gap is reported, replay the source
+ * data that covers it. Inserts are idempotent via the unique
+ * (asset, source, timestamp) index, so re-running is safe.
+ *
+ * Source files are `history-<asset>.json` arrays of
+ *   { asset, price, decimals, source, timestamp }   // timestamp = epoch seconds
+ * found under a data directory (default: repo `data/`, then `api/data/`).
+ *
+ * Usage:
+ *   tsx api/scripts/backfill-history.ts --asset BTC --from 1719378000 --to 1719378600 [dataDir]
+ *   tsx api/scripts/backfill-history.ts --all [dataDir]        # replay every file
+ *   tsx api/scripts/backfill-history.ts --asset BTC --dry-run
+ *
+ * Requires DATABASE_URL.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import dotenv from 'dotenv';
+import { Pool } from 'pg';
+
+const envPath = path.resolve(__dirname, '../.env');
+if (fs.existsSync(envPath)) {
+  dotenv.config({ path: envPath });
+}
+
+const args = process.argv.slice(2);
+function flag(name: string): string | undefined {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 ? args[i + 1] : undefined;
+}
+const dryRun = args.includes('--dry-run');
+const all = args.includes('--all');
+const asset = flag('asset')?.toUpperCase();
+const from = flag('from') ? Number(flag('from')) : undefined;
+const to = flag('to') ? Number(flag('to')) : undefined;
+
+const positional = args.filter((a, i) => !a.startsWith('--') && !args[i - 1]?.match(/^--(asset|from|to)$/));
+const candidateDirs = [
+  positional[0],
+  path.resolve(__dirname, '../../data'),
+  path.resolve(__dirname, '../data'),
+  path.resolve(__dirname, '../../services/aggregator/data'),
+].filter(Boolean) as string[];
+
+const dataDir = candidateDirs.find((d) => fs.existsSync(d));
+if (!dataDir) {
+  console.error(`No data directory found. Looked in:\n  ${candidateDirs.join('\n  ')}`);
+  process.exit(2);
+}
+
+interface Snapshot {
+  asset: string;
+  price: string | number;
+  decimals: number;
+  source: string;
+  timestamp: number;
+}
+
+function loadFile(file: string): Snapshot[] {
+  const raw = fs.readFileSync(file, 'utf-8');
+  if (!raw.trim()) return [];
+  const parsed = JSON.parse(raw);
+  return Array.isArray(parsed) ? parsed : [];
+}
+
+async function main(): Promise<void> {
+  if (!all && !asset) {
+    console.error('Pass --asset <ASSET> (optionally --from/--to epoch seconds) or --all');
+    process.exit(2);
+  }
+  if (!process.env.DATABASE_URL) {
+    console.error('DATABASE_URL is not set');
+    process.exit(2);
+  }
+
+  const files = fs
+    .readdirSync(dataDir)
+    .filter((f) => /^history-.+\.json$/i.test(f))
+    .filter((f) => all || f.toLowerCase() === `history-${asset!.toLowerCase()}.json`);
+
+  if (files.length === 0) {
+    console.error(`No matching history-*.json files in ${dataDir}`);
+    process.exit(2);
+  }
+
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  let considered = 0;
+  let inserted = 0;
+
+  for (const file of files) {
+    const rows = loadFile(path.join(dataDir, file)).filter((r) => {
+      if (from !== undefined && r.timestamp < from) return false;
+      if (to !== undefined && r.timestamp > to) return false;
+      return true;
+    });
+    considered += rows.length;
+    if (dryRun) {
+      console.log(`[dry-run] ${file}: ${rows.length} row(s) in range`);
+      continue;
+    }
+    for (const r of rows) {
+      const res = await pool.query(
+        `INSERT INTO price_history (asset, price, decimals, source, timestamp)
+         VALUES ($1, $2, $3, $4, $5)
+         ON CONFLICT (asset, source, timestamp) DO NOTHING`,
+        [String(r.asset).toUpperCase(), String(r.price), r.decimals, r.source, r.timestamp],
+      );
+      inserted += res.rowCount ?? 0;
+    }
+    console.log(`${file}: considered ${rows.length}, inserted ${inserted}`);
+  }
+
+  await pool.end();
+  console.log(
+    dryRun
+      ? `\n[dry-run] ${considered} row(s) would be replayed from ${files.length} file(s)`
+      : `\nBackfill complete: ${inserted}/${considered} new row(s) from ${files.length} file(s)`,
+  );
+  console.log('Re-run `npm run history:gaps` to confirm the gap is closed.');
+}
+
+main().catch((err) => {
+  console.error('Backfill failed:', err);
+  process.exit(2);
+});

--- a/api/scripts/detect-history-gaps.ts
+++ b/api/scripts/detect-history-gaps.ts
@@ -1,0 +1,150 @@
+#!/usr/bin/env tsx
+/**
+ * Detect gaps in `price_history` and report them (issue #421).
+ *
+ * A "gap" is a stretch between two consecutive snapshots for the same asset that
+ * is longer than the expected cadence. Gaps break VWAP/EMA consumers and audits.
+ *
+ * Usage:
+ *   tsx api/scripts/detect-history-gaps.ts [--asset BTC] [--since 2026-01-01] [--json]
+ *
+ * Environment:
+ *   DATABASE_URL                     required
+ *   HISTORY_EXPECTED_INTERVAL_SEC    expected cadence between snapshots (default 60)
+ *   HISTORY_GAP_ALERT_SEC           gap size that escalates to an alert / non-zero
+ *                                    exit (default 900 = 15 min)
+ *   HISTORY_LOOKBACK_DAYS            window to scan when --since is absent (default 7)
+ *
+ * Exit codes:
+ *   0  no gap exceeded HISTORY_GAP_ALERT_SEC
+ *   1  at least one gap exceeded the alert threshold
+ *   2  usage / connection error
+ */
+
+import fs from 'fs';
+import path from 'path';
+import dotenv from 'dotenv';
+import { Pool } from 'pg';
+
+const envPath = path.resolve(__dirname, '../.env');
+if (fs.existsSync(envPath)) {
+  dotenv.config({ path: envPath });
+}
+
+const args = process.argv.slice(2);
+function flag(name: string): string | undefined {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 ? args[i + 1] : undefined;
+}
+const asJson = args.includes('--json');
+const assetFilter = flag('asset')?.toUpperCase();
+const expectedInterval = Number(process.env.HISTORY_EXPECTED_INTERVAL_SEC ?? 60);
+const alertThreshold = Number(process.env.HISTORY_GAP_ALERT_SEC ?? 900);
+const lookbackDays = Number(process.env.HISTORY_LOOKBACK_DAYS ?? 7);
+
+const sinceArg = flag('since');
+const sinceMs = sinceArg
+  ? Date.parse(sinceArg)
+  : Date.now() - lookbackDays * 86_400_000;
+if (Number.isNaN(sinceMs)) {
+  console.error(`Invalid --since value: ${sinceArg}`);
+  process.exit(2);
+}
+
+interface Gap {
+  asset: string;
+  startTs: number;
+  endTs: number;
+  gapSeconds: number;
+  missingSnapshots: number;
+}
+
+async function main(): Promise<void> {
+  if (!process.env.DATABASE_URL) {
+    console.error('DATABASE_URL is not set');
+    process.exit(2);
+  }
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+  // `price_history.timestamp` is stored as epoch seconds by the API writer.
+  const params: unknown[] = [Math.floor(sinceMs / 1000)];
+  let where = 'timestamp >= $1';
+  if (assetFilter) {
+    params.push(assetFilter);
+    where += ` AND asset = $${params.length}`;
+  }
+
+  const { rows } = await pool.query<{ asset: string; ts: string }>(
+    `SELECT asset, timestamp::bigint AS ts
+       FROM price_history
+      WHERE ${where}
+      ORDER BY asset, timestamp`,
+    params,
+  );
+  await pool.end();
+
+  const byAsset = new Map<string, number[]>();
+  for (const row of rows) {
+    const list = byAsset.get(row.asset) ?? [];
+    list.push(Number(row.ts));
+    byAsset.set(row.asset, list);
+  }
+
+  const gaps: Gap[] = [];
+  for (const [asset, tsList] of byAsset) {
+    for (let i = 1; i < tsList.length; i += 1) {
+      const delta = tsList[i] - tsList[i - 1];
+      if (delta > expectedInterval * 1.5) {
+        gaps.push({
+          asset,
+          startTs: tsList[i - 1],
+          endTs: tsList[i],
+          gapSeconds: delta,
+          missingSnapshots: Math.max(0, Math.round(delta / expectedInterval) - 1),
+        });
+      }
+    }
+    if (tsList.length === 0 && assetFilter) {
+      gaps.push({ asset, startTs: 0, endTs: 0, gapSeconds: Infinity, missingSnapshots: -1 });
+    }
+  }
+
+  const alerting = gaps.filter((g) => g.gapSeconds > alertThreshold);
+  const summary = {
+    scannedAssets: byAsset.size,
+    scannedRows: rows.length,
+    windowStart: new Date(sinceMs).toISOString(),
+    expectedInterval,
+    alertThreshold,
+    totalGaps: gaps.length,
+    alertingGaps: alerting.length,
+    gaps: gaps.sort((a, b) => b.gapSeconds - a.gapSeconds),
+  };
+
+  if (asJson) {
+    console.log(JSON.stringify(summary, null, 2));
+  } else {
+    console.log(
+      `Scanned ${summary.scannedRows} rows across ${summary.scannedAssets} assets since ${summary.windowStart}`,
+    );
+    console.log(`Found ${gaps.length} gap(s); ${alerting.length} exceed ${alertThreshold}s`);
+    for (const g of summary.gaps.slice(0, 50)) {
+      const from = new Date(g.startTs * 1000).toISOString();
+      const to = new Date(g.endTs * 1000).toISOString();
+      const mark = g.gapSeconds > alertThreshold ? 'ALERT' : 'warn ';
+      console.log(`  [${mark}] ${g.asset.padEnd(8)} ${from} -> ${to}  ${g.gapSeconds}s  (~${g.missingSnapshots} missing)`);
+    }
+    console.log(
+      alerting.length > 0
+        ? `\nBackfill with: npm run history:backfill -- --asset <ASSET> --from <startTs> --to <endTs>`
+        : '\nNo gaps beyond threshold.',
+    );
+  }
+
+  process.exit(alerting.length > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error('Gap detection failed:', err);
+  process.exit(2);
+});

--- a/api/src/observability/trace-propagation.ts
+++ b/api/src/observability/trace-propagation.ts
@@ -1,0 +1,85 @@
+import { context, propagation, trace, SpanKind, Span } from '@opentelemetry/api';
+
+/**
+ * Cross-region distributed tracing propagation (issue #419).
+ *
+ * The replication path spans regions: source fetch -> aggregation -> replication
+ * bus -> API read. For those spans to land in a single trace, W3C trace context
+ * must ride along on every replication-bus message, not just HTTP requests.
+ *
+ * These helpers inject/extract trace context into a plain string map that can be
+ * serialized onto any transport (Kafka/NATS headers, SQS attributes, a JSON
+ * envelope field). They are transport-agnostic on purpose.
+ */
+
+export type TraceCarrier = Record<string, string>;
+
+const setter = {
+  set(carrier: TraceCarrier, key: string, value: string): void {
+    carrier[key] = value;
+  },
+};
+
+const getter = {
+  keys(carrier: TraceCarrier): string[] {
+    return Object.keys(carrier);
+  },
+  get(carrier: TraceCarrier, key: string): string | undefined {
+    return carrier[key];
+  },
+};
+
+/** Serialize the active trace context (traceparent/tracestate) into `carrier`. */
+export function injectTraceContext(carrier: TraceCarrier = {}): TraceCarrier {
+  propagation.inject(context.active(), carrier, setter);
+  return carrier;
+}
+
+/**
+ * Run `fn` with the trace context carried on an inbound replication message, so
+ * spans created inside `fn` become children of the originating request's trace.
+ */
+export function withExtractedContext<T>(carrier: TraceCarrier, fn: () => T): T {
+  const active = propagation.extract(context.active(), carrier, getter);
+  return context.with(active, fn);
+}
+
+/**
+ * Start a span for a cross-region replication hop. Records the source and target
+ * region plus the enqueue->dequeue transit time so the tracing UI can show a
+ * per-hop latency breakdown.
+ */
+export function startReplicationSpan(
+  name: string,
+  attrs: {
+    sourceRegion: string;
+    targetRegion: string;
+    asset?: string;
+    busTransitMs?: number;
+    kind?: SpanKind;
+  },
+): Span {
+  const tracer = trace.getTracer('stellar-oracle-replication');
+  const span = tracer.startSpan(name, { kind: attrs.kind ?? SpanKind.PRODUCER });
+  span.setAttribute('region.source', attrs.sourceRegion);
+  span.setAttribute('region.target', attrs.targetRegion);
+  span.setAttribute('region.cross_region', attrs.sourceRegion !== attrs.targetRegion);
+  if (attrs.asset) span.setAttribute('oracle.asset', attrs.asset);
+  if (typeof attrs.busTransitMs === 'number') {
+    span.setAttribute('replication.bus_transit_ms', attrs.busTransitMs);
+  }
+  return span;
+}
+
+/**
+ * Attributes describing a single leg of the cross-region path, for the
+ * "cross-region latency breakdown" panel. Emit one per stage
+ * (`source_fetch`, `aggregation`, `replication`, `api_read`).
+ */
+export function regionLatencyAttributes(stage: string, region: string, elapsedMs: number): Record<string, string | number> {
+  return {
+    'pipeline.stage': stage,
+    'pipeline.region': region,
+    'pipeline.stage_latency_ms': Math.round(elapsedMs),
+  };
+}

--- a/config/cost-invoices.json
+++ b/config/cost-invoices.json
@@ -1,0 +1,13 @@
+{
+  "currency": "USD",
+  "note": "Monthly reconciliation of the modeled requested-capacity run rate against the provider invoice. Append one entry per month; run `npm run cost:reconcile` to compute variance.",
+  "invoices": [
+    {
+      "month": "2026-07",
+      "invoicedTotal": 27.4,
+      "byService": { "api": 9.1, "aggregator": 7.8, "timescaledb": 10.5 },
+      "reconciledBy": "platform-oncall",
+      "notes": "Baseline capture; egress and control-plane fees folded into per-service split."
+    }
+  ]
+}

--- a/docs/dashboards/cost-budget.json
+++ b/docs/dashboards/cost-budget.json
@@ -1,0 +1,12 @@
+{
+  "title": "Cost & Budget",
+  "panels": [
+    { "title": "Requested monthly cost (total)", "query": "stellar_oracle:requested_monthly_cost_usd" },
+    { "title": "Budget warning threshold", "query": "vector(24)" },
+    { "title": "Budget exceeded threshold", "query": "vector(30)" },
+    { "title": "Requested monthly cost by service / team", "query": "stellar_oracle:requested_monthly_cost_usd_by_service_team" },
+    { "title": "Budget utilization %", "query": "stellar_oracle:requested_monthly_cost_usd / 30 * 100" },
+    { "title": "Active cost alerts", "query": "ALERTS{alertname=~\"StellarOracleCostBudget.*\"}" },
+    { "title": "Modeled vs invoiced variance %", "query": "stellar_oracle:cost_invoice_variance_percent" }
+  ]
+}

--- a/docs/dashboards/cross-region-tracing.json
+++ b/docs/dashboards/cross-region-tracing.json
@@ -1,0 +1,12 @@
+{
+  "title": "Cross-Region Tracing",
+  "panels": [
+    { "title": "Stage latency p95 (source_fetch)", "query": "histogram_quantile(0.95, sum(rate(pipeline_stage_latency_ms_bucket{stage=\"source_fetch\"}[5m])) by (le, region))" },
+    { "title": "Stage latency p95 (aggregation)", "query": "histogram_quantile(0.95, sum(rate(pipeline_stage_latency_ms_bucket{stage=\"aggregation\"}[5m])) by (le, region))" },
+    { "title": "Replication bus transit p95 by region pair", "query": "histogram_quantile(0.95, sum(rate(replication_bus_transit_ms_bucket[5m])) by (le, region_source, region_target))" },
+    { "title": "Stage latency p95 (api_read)", "query": "histogram_quantile(0.95, sum(rate(pipeline_stage_latency_ms_bucket{stage=\"api_read\"}[5m])) by (le, region))" },
+    { "title": "End-to-end trace duration p95 (source -> api read)", "query": "histogram_quantile(0.95, sum(rate(trace_end_to_end_duration_ms_bucket[5m])) by (le))" },
+    { "title": "Cross-region spans / sec", "query": "sum(rate(span_count_total{cross_region=\"true\"}[5m])) by (region_source, region_target)" },
+    { "title": "Traces missing a replication span", "query": "sum(rate(trace_missing_replication_span_total[5m]))" }
+  ]
+}

--- a/docs/runbooks/cost-budget-observability.md
+++ b/docs/runbooks/cost-budget-observability.md
@@ -1,0 +1,75 @@
+# Cost & budget observability
+
+Issue #418. Keeps infrastructure cost continuously visible against the monthly
+budget so cost discipline survives launch.
+
+## Sources of truth
+
+| Concern | File |
+| --- | --- |
+| Requested-capacity cost model (per service + owning team) | `config/cost-model.json` |
+| Recording rules + budget alerts | `k8s/cost-optimization/prometheus-rule.yaml` |
+| Namespace guardrail (ResourceQuota) | `k8s/cost-optimization/budget.yaml` |
+| Grafana dashboard | `docs/dashboards/cost-budget.json` |
+| Alertmanager routing | `monitoring/alertmanager-cost-routes.yaml` |
+| Recorded monthly invoices | `config/cost-invoices.json` |
+
+## 1. Visualize the cost model per service and team
+
+`docs/dashboards/cost-budget.json` renders:
+
+- **Requested monthly cost (total)** — `stellar_oracle:requested_monthly_cost_usd`,
+  with static warning ($24 = 80%) and exceeded ($30 = 100%) threshold lines.
+- **Requested monthly cost by service / team** —
+  `stellar_oracle:requested_monthly_cost_usd_by_service_team`, grouped by the
+  `cost.stellar.org/service` and `cost.stellar.org/team` pod labels, so each
+  team sees its own run rate and chargeback share.
+- **Budget utilization %**, **Active cost alerts**, and **Modeled vs invoiced
+  variance %** (from the reconciliation step below).
+
+The recording rules already exist in production; this issue adds the dashboard
+that consumes them. The modeled numbers can be regenerated any time with
+`npm run cost:analyze` and are verified in CI by `npm run cost:check`.
+
+## 2. Confirm budget warning / exceeded alerts route correctly
+
+Alerts and their labels (defined in `k8s/cost-optimization/prometheus-rule.yaml`):
+
+| Alert | Fires at | Labels |
+| --- | --- | --- |
+| `StellarOracleCostBudgetWarning` | run rate > $24 for 30m | `severity=warning, team=platform, cost_center=stellar-oracle` |
+| `StellarOracleCostBudgetExceeded` | run rate > $30 for 15m | `severity=critical, team=platform, cost_center=stellar-oracle` |
+
+Merge `monitoring/alertmanager-cost-routes.yaml` into the org Alertmanager
+config, then prove routing without waiting for a breach:
+
+```sh
+amtool config routes test --config.file=alertmanager.yml \
+  alertname=StellarOracleCostBudgetWarning severity=warning team=platform cost_center=stellar-oracle
+# expect: cost-budget-warning  (Slack #stellar-oracle-cost)
+
+amtool config routes test --config.file=alertmanager.yml \
+  alertname=StellarOracleCostBudgetExceeded severity=critical team=platform cost_center=stellar-oracle
+# expect: cost-budget-exceeded  (Slack + PagerDuty)
+```
+
+For an end-to-end check, temporarily lower the warning threshold in a staging
+`PrometheusRule` (e.g. `> 1`), confirm the notification lands in
+`#stellar-oracle-cost`, then revert.
+
+## 3. Reconcile the model with actual invoices monthly
+
+On the first business day of each month:
+
+1. Pull the previous month's provider invoice and split it per service using the
+   `cost.stellar.org/service` allocation labels (or the provider's own tags).
+2. Append an entry to `config/cost-invoices.json` (`month`, `invoicedTotal`,
+   `byService`, `reconciledBy`, `notes`).
+3. Run `npm run cost:reconcile` and review per-service variance. `--check` exits
+   non-zero when the latest variance exceeds `COST_VARIANCE_TOLERANCE_PCT`
+   (default 15%).
+4. If variance is out of tolerance, update `config/cost-model.json` rates to the
+   provider's effective rates, run `npm run cost:analyze`, and open a PR so the
+   change is reviewable. Feed
+   `stellar_oracle:cost_invoice_variance_percent` from the recorded variance so
+   the dashboard panel reflects reality.

--- a/docs/runbooks/cross-region-tracing.md
+++ b/docs/runbooks/cross-region-tracing.md
@@ -1,0 +1,63 @@
+# Cross-region distributed tracing
+
+Issue #419. Trace a request end-to-end across regions: **source fetch ->
+aggregation -> replication bus -> API read** must appear as one trace.
+
+## Propagation across the replication bus
+
+HTTP hops already propagate W3C trace context via the OpenTelemetry auto
+instrumentation in `api/src/observability/tracing.ts`. The gap was the
+region-to-region replication bus, which is not HTTP.
+
+- `api/src/observability/trace-propagation.ts` — `injectTraceContext(carrier)` /
+  `withExtractedContext(carrier, fn)` serialize the active context into a plain
+  string map that rides on any bus transport (Kafka/NATS headers, SQS message
+  attributes, or a `trace` field in the JSON envelope).
+- `services/aggregator/src/replication/trace-context.ts` — dependency-free
+  `traceparent` / `tracestate` parse/format for the aggregator, which does not
+  ship the OTel SDK. `propagateForHop(inbound, regionId)` keeps the trace id,
+  mints a new span id per hop, and records the region in `tracestate`.
+- `RegionPriceRecord` now carries optional `traceparent` / `tracestate`, and
+  `RegionPriceReplicator.outboundTraceHeaders(asset)` produces the headers for
+  the next hop from the last inbound record.
+
+Producer side:
+
+```ts
+const headers = replicator.outboundTraceHeaders(price.asset);
+bus.publish(topic, { ...payload, traceparent: headers.traceparent, tracestate: headers.tracestate });
+```
+
+Consumer side:
+
+```ts
+const ctx = parseTraceparent({ traceparent: msg.traceparent, tracestate: msg.tracestate });
+replicator.mergeRemotePrice({ region, asset, price, decimals, timestamp,
+  traceparent: msg.traceparent, tracestate: msg.tracestate });
+```
+
+## Verify a single trace spans all four stages
+
+1. Enable tracing on the API and aggregator in two regions
+   (`TRACING_ENABLED=true`, shared OTLP collector / Tempo).
+2. Issue one read: `curl -H 'traceparent: 00-<32 hex>-<16 hex>-01' \
+   https://<region-a>/api/v2/prices/BTC`.
+3. In the tracing UI, open that trace id. It must contain, under one root:
+   - `source.fetch` span (region A)
+   - `price.aggregate` span (region A)
+   - `replication.publish` -> `replication.consume` spans with
+     `region.source=a`, `region.target=b`, `region.cross_region=true`
+   - `GET /api/v2/prices/:asset` span served from region B's replica
+4. Automated check: `api/tests/trace-propagation.test.ts` asserts an
+   inject -> extract round trip preserves the trace id and that
+   `propagateForHop` keeps the id while changing the span id.
+
+## Cross-region latency breakdown
+
+Each stage emits `regionLatencyAttributes(stage, region, elapsedMs)` on its span
+(`pipeline.stage`, `pipeline.region`, `pipeline.stage_latency_ms`), and
+replication spans add `replication.bus_transit_ms` (enqueue -> dequeue). Feed
+those into the histograms behind `docs/dashboards/cross-region-tracing.json` for
+per-stage and per-region-pair p95 breakdowns, plus an alert on
+`trace_missing_replication_span_total` catching traces that never crossed the
+bus.

--- a/docs/runbooks/history-backfill-and-gap-detection.md
+++ b/docs/runbooks/history-backfill-and-gap-detection.md
@@ -1,0 +1,54 @@
+# History backfill & gap detection
+
+Issue #421. Keeps `price_history` continuous and complete so VWAP/EMA consumers
+and audits can trust it.
+
+## Gap detection
+
+`api/scripts/detect-history-gaps.ts` (`npm run history:gaps`, run from `api/`)
+scans `price_history`, groups snapshots per asset, and flags every interval that
+is longer than `1.5 x HISTORY_EXPECTED_INTERVAL_SEC`.
+
+| Env var | Default | Meaning |
+| --- | --- | --- |
+| `HISTORY_EXPECTED_INTERVAL_SEC` | `60` | expected cadence between snapshots |
+| `HISTORY_GAP_ALERT_SEC` | `900` | gap size that escalates to an alert / non-zero exit |
+| `HISTORY_LOOKBACK_DAYS` | `7` | window scanned when `--since` is omitted |
+
+```sh
+cd api
+npm run history:gaps                       # human-readable, last 7 days
+npm run history:gaps -- --asset BTC --json  # machine-readable, one asset
+npm run history:gaps -- --since 2026-01-01
+```
+
+Exit `0` = clean, `1` = a gap exceeded `HISTORY_GAP_ALERT_SEC`, `2` = usage error.
+
+## Alerting
+
+`.github/workflows/history-gap-detection.yml` runs the detector hourly against
+`secrets.HISTORY_DATABASE_URL`. A gap over threshold fails the job, which opens a
+`data` / `alert` issue with the offending window and the backfill command. Wire
+the same script into Prometheus (via a `textfile` collector emitting
+`price_history_max_gap_seconds`) if you prefer alerting through Alertmanager.
+
+## Backfill
+
+`api/scripts/backfill-history.ts` (`npm run history:backfill`) replays source
+`history-<asset>.json` snapshot files into `price_history`. Inserts are
+idempotent through the unique `(asset, source, timestamp)` index.
+
+```sh
+cd api
+npm run history:backfill -- --asset BTC --from 1719378000 --to 1719378600
+npm run history:backfill -- --asset BTC --dry-run
+npm run history:backfill -- --all            # replay every source file
+```
+
+## Standard recovery loop
+
+1. `npm run history:gaps` reports a gap for asset `X` between `t0` and `t1`.
+2. `npm run history:backfill -- --asset X --from t0 --to t1`.
+3. `npm run history:gaps -- --asset X` to confirm the gap is closed.
+4. If source files do not cover the window, request a re-fetch from the upstream
+   provider or accept the gap with a documented note in the audit log.

--- a/docs/runbooks/price-correctness-validation.md
+++ b/docs/runbooks/price-correctness-validation.md
@@ -1,0 +1,44 @@
+# Price correctness validation suite
+
+Issue #420. Proves aggregated prices are *correct*, not merely *available* — a
+wrong price is worse than no price.
+
+## What it checks
+
+`scripts/validate-price-correctness.mjs` (`npm run validate:prices`) replays the
+cases in `verification/fixtures/price-correctness-cases.json` through the
+reference aggregation logic (median, matching
+`services/aggregator/src/price-aggregation/aggregator.ts`, plus
+deviation-from-median outlier rejection mirroring the circuit breaker's
+`deviationThreshold`) and asserts, per case:
+
+1. **Median correctness** — the aggregate matches the known-good historical value
+   within `medianTolerancePercent`.
+2. **Outlier handling** — exactly the sources marked `expectedOutliers` are
+   dropped (deviation from the all-source median above `outlierDeviationPercent`).
+3. **Robustness** — injecting one extra gross outlier (100x) must not move the
+   resulting median beyond tolerance.
+
+Exit non-zero on any failure, with each failure printed.
+
+## Adding cases
+
+Append to `verification/fixtures/price-correctness-cases.json`. Prefer real
+snapshots pulled from `price_history` at a timestamp whose correct aggregate is
+known from an independent source (exchange VWAP, a second oracle). Each case:
+
+```json
+{
+  "name": "descriptive label",
+  "asset": "BTC",
+  "sources": [{ "source": "coinbase", "price": 42010.5 }, ...],
+  "expectedMedian": 42010.5,
+  "expectedOutliers": ["source-to-drop"]
+}
+```
+
+## CI
+
+The `price-correctness` job in `.github/workflows/ci.yml` runs `npm run
+validate:prices` on every push and PR to `main` / `develop`, so any change that
+touches the aggregator (or the fixtures) is gated on it.

--- a/monitoring/alertmanager-cost-routes.yaml
+++ b/monitoring/alertmanager-cost-routes.yaml
@@ -1,0 +1,48 @@
+# Alertmanager routing for cost / budget alerts (issue #418).
+#
+# Merge this `route` child and these `receivers` into the organization
+# Alertmanager config. The match labels are emitted by
+# k8s/cost-optimization/prometheus-rule.yaml:
+#   - StellarOracleCostBudgetWarning  -> severity=warning,  team=platform, cost_center=stellar-oracle
+#   - StellarOracleCostBudgetExceeded -> severity=critical, team=platform, cost_center=stellar-oracle
+#
+# Verify routing without waiting for a real breach:
+#   amtool config routes test --config.file=alertmanager.yml \
+#     alertname=StellarOracleCostBudgetWarning severity=warning team=platform cost_center=stellar-oracle
+#   amtool config routes test --config.file=alertmanager.yml \
+#     alertname=StellarOracleCostBudgetExceeded severity=critical team=platform cost_center=stellar-oracle
+# The first must resolve to `cost-budget-warning`, the second to `cost-budget-exceeded`.
+
+route:
+  routes:
+    - matchers:
+        - cost_center = "stellar-oracle"
+        - severity = "warning"
+      receiver: cost-budget-warning
+      group_by: ["alertname"]
+      repeat_interval: 12h
+    - matchers:
+        - cost_center = "stellar-oracle"
+        - severity = "critical"
+      receiver: cost-budget-exceeded
+      group_by: ["alertname"]
+      repeat_interval: 1h
+      continue: false
+
+receivers:
+  - name: cost-budget-warning
+    slack_configs:
+      - channel: "#stellar-oracle-cost"
+        title: "{{ .CommonAnnotations.summary }}"
+        text: "{{ .CommonAnnotations.description }}\nRunbook: {{ .CommonAnnotations.runbook_url }}"
+        send_resolved: true
+  - name: cost-budget-exceeded
+    slack_configs:
+      - channel: "#stellar-oracle-cost"
+        title: "[CRITICAL] {{ .CommonAnnotations.summary }}"
+        text: "{{ .CommonAnnotations.description }}\nRunbook: {{ .CommonAnnotations.runbook_url }}"
+        send_resolved: true
+    pagerduty_configs:
+      - service_key_file: /etc/alertmanager/secrets/pagerduty-stellar-oracle
+        description: "{{ .CommonAnnotations.summary }}"
+        severity: critical

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "plugin:test": "node scripts/plugin-test.mjs",
     "cost:analyze": "node scripts/analyze-infrastructure-costs.mjs",
     "cost:check": "node scripts/analyze-infrastructure-costs.mjs --check",
+    "cost:reconcile": "node scripts/reconcile-cost-invoices.mjs",
+    "validate:prices": "node scripts/validate-price-correctness.mjs",
     "rent:extend": "tsx scripts/extend-ttl-job.ts",
     "install:all": "npm install",
     "prepare": "husky"

--- a/scripts/reconcile-cost-invoices.mjs
+++ b/scripts/reconcile-cost-invoices.mjs
@@ -1,0 +1,85 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+// Reconcile the modeled requested-capacity run rate (config/cost-model.json) with
+// recorded provider invoices (config/cost-invoices.json) — issue #418.
+//
+//   npm run cost:reconcile              # report every recorded month
+//   npm run cost:reconcile -- 2026-07   # report a single month
+//   npm run cost:reconcile -- --check   # non-zero exit if latest variance > tolerance
+//
+// Tolerance defaults to 15% and can be overridden with COST_VARIANCE_TOLERANCE_PCT.
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const modelPath = path.join(root, "config", "cost-model.json");
+const invoicesPath = path.join(root, "config", "cost-invoices.json");
+const tolerancePct = Number(process.env.COST_VARIANCE_TOLERANCE_PCT ?? 15);
+
+function aggregate(service, profile) {
+  const v = service[profile];
+  return {
+    cpu: v.replicas * v.cpuCoresPerReplica,
+    memory: v.replicas * v.memoryGibPerReplica,
+    storage: v.storageGib,
+  };
+}
+
+function monthlyCost(resources, model) {
+  return (
+    resources.cpu * model.rates.cpuPerVcpuHour * model.hoursPerMonth +
+    resources.memory * model.rates.memoryPerGibHour * model.hoursPerMonth +
+    resources.storage * model.rates.storagePerGibMonth
+  );
+}
+
+function variancePct(modeled, invoiced) {
+  if (invoiced === 0) return 0;
+  return ((modeled - invoiced) / invoiced) * 100;
+}
+
+function money(v) {
+  return `$${v.toFixed(2)}`;
+}
+
+const model = JSON.parse(await readFile(modelPath, "utf8"));
+const { invoices } = JSON.parse(await readFile(invoicesPath, "utf8"));
+
+const modeledByService = Object.fromEntries(
+  model.services.map((s) => [s.name, monthlyCost(aggregate(s, "optimized"), model)]),
+);
+const modeledTotal = Object.values(modeledByService).reduce((a, b) => a + b, 0);
+
+const requestedMonth = process.argv.find((a) => /^\d{4}-\d{2}$/.test(a));
+const checkMode = process.argv.includes("--check");
+const rows = requestedMonth
+  ? invoices.filter((i) => i.month === requestedMonth)
+  : [...invoices].sort((a, b) => a.month.localeCompare(b.month));
+
+if (rows.length === 0) {
+  throw new Error(`No invoice recorded${requestedMonth ? ` for ${requestedMonth}` : ""} in config/cost-invoices.json`);
+}
+
+let worst = 0;
+for (const invoice of rows) {
+  const totalVariance = variancePct(modeledTotal, invoice.invoicedTotal);
+  worst = Math.max(worst, Math.abs(totalVariance));
+  console.log(`\n${invoice.month}  (reconciled by ${invoice.reconciledBy ?? "unknown"})`);
+  console.log(`  modeled total   ${money(modeledTotal)}`);
+  console.log(`  invoiced total  ${money(invoice.invoicedTotal)}`);
+  console.log(`  variance        ${totalVariance.toFixed(1)}%  (tolerance ${tolerancePct}%)`);
+  for (const [name, invoiced] of Object.entries(invoice.byService ?? {})) {
+    const modeled = modeledByService[name] ?? 0;
+    console.log(
+      `    ${name.padEnd(12)} modeled ${money(modeled).padStart(9)}  invoiced ${money(invoiced).padStart(9)}  variance ${variancePct(modeled, invoiced).toFixed(1)}%`,
+    );
+  }
+  if (invoice.notes) console.log(`  notes: ${invoice.notes}`);
+}
+
+if (checkMode && worst > tolerancePct) {
+  console.error(`\nLatest reconciliation variance ${worst.toFixed(1)}% exceeds tolerance ${tolerancePct}%`);
+  process.exit(1);
+}
+console.log("");

--- a/scripts/validate-price-correctness.mjs
+++ b/scripts/validate-price-correctness.mjs
@@ -1,0 +1,98 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+// Price correctness validation suite (issue #420).
+//
+// Availability is not correctness: a wrong price is worse than no price. This
+// harness replays known aggregation cases through the reference median +
+// MAD-outlier logic and asserts:
+//   1. median correctness  - aggregate matches the known-good value within tol
+//   2. outlier handling    - the sources a correct impl must drop are dropped
+//   3. robustness          - injecting one extra gross outlier must not move the
+//                            median by more than the tolerance
+//
+// Run:  npm run validate:prices        (from repo root)
+// CI:   .github/workflows/ci.yml `price-correctness` job, on every push/PR.
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const fixturePath = path.join(root, "verification", "fixtures", "price-correctness-cases.json");
+
+/** Median matching services/aggregator/src/price-aggregation/aggregator.ts. */
+function median(values) {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+/**
+ * Outlier detection: a source whose price deviates from the all-source median by
+ * more than `deviationPercent` is rejected. Mirrors the circuit breaker's
+ * deviation-threshold approach in the aggregator service and, unlike a bare MAD
+ * score, is not destabilised by a single extreme injected value.
+ */
+function deviationOutliers(sources, deviationPercent) {
+  const med = median(sources.map((s) => s.price));
+  const outliers = new Set();
+  for (const s of sources) {
+    if (med !== 0 && Math.abs(s.price - med) / Math.abs(med) * 100 > deviationPercent) {
+      outliers.add(s.source);
+    }
+  }
+  return outliers;
+}
+
+function pctDiff(a, b) {
+  return b === 0 ? 0 : Math.abs(a - b) / Math.abs(b) * 100;
+}
+
+const fixture = JSON.parse(await readFile(fixturePath, "utf8"));
+const medianTol = fixture.medianTolerancePercent ?? 0.01;
+const deviationPercent = fixture.outlierDeviationPercent ?? 10;
+
+const failures = [];
+let checks = 0;
+
+for (const c of fixture.cases) {
+  const outliers = deviationOutliers(c.sources, deviationPercent);
+
+  // 1. outlier handling
+  checks += 1;
+  const expectedOutliers = new Set(c.expectedOutliers ?? []);
+  const sameOutliers =
+    outliers.size === expectedOutliers.size && [...outliers].every((o) => expectedOutliers.has(o));
+  if (!sameOutliers) {
+    failures.push(`${c.name}: outliers [${[...outliers]}] != expected [${[...expectedOutliers]}]`);
+  }
+
+  // 2. median correctness (after dropping detected outliers)
+  checks += 1;
+  const kept = c.sources.filter((s) => !outliers.has(s.source)).map((s) => s.price);
+  const agg = median(kept);
+  const diff = pctDiff(agg, c.expectedMedian);
+  if (diff > medianTol) {
+    failures.push(`${c.name}: median ${agg} vs expected ${c.expectedMedian} (${diff.toFixed(4)}% > ${medianTol}%)`);
+  }
+
+  // 3. robustness - one injected gross outlier must not move the median
+  checks += 1;
+  const perturbed = [...c.sources, { source: "__inject__", price: c.expectedMedian * 100 }];
+  const perturbedOutliers = deviationOutliers(perturbed, deviationPercent);
+  const perturbedKept = perturbed.filter((s) => !perturbedOutliers.has(s.source)).map((s) => s.price);
+  const perturbedAgg = median(perturbedKept);
+  const perturbedDiff = pctDiff(perturbedAgg, c.expectedMedian);
+  if (perturbedDiff > medianTol) {
+    failures.push(
+      `${c.name}: injected outlier moved median to ${perturbedAgg} (${perturbedDiff.toFixed(4)}% > ${medianTol}%)`,
+    );
+  }
+}
+
+console.log(`Price correctness suite: ${fixture.cases.length} case(s), ${checks} check(s)`);
+if (failures.length > 0) {
+  console.error(`\n${failures.length} FAILURE(S):`);
+  for (const f of failures) console.error(`  - ${f}`);
+  process.exit(1);
+}
+console.log("All price correctness checks passed.");

--- a/services/aggregator/src/replication/price-crdt.ts
+++ b/services/aggregator/src/replication/price-crdt.ts
@@ -8,6 +8,9 @@ export interface RegionPriceRecord {
   timestamp: number;
   receivedAt: number;
   source: 'local' | 'remote';
+  /** W3C trace context carried across the replication bus (issue #419). */
+  traceparent?: string;
+  tracestate?: string;
 }
 
 export class LwwPriceRegister {

--- a/services/aggregator/src/replication/region-price-replicator.ts
+++ b/services/aggregator/src/replication/region-price-replicator.ts
@@ -1,6 +1,7 @@
 import { config } from '../infrastructure/config';
 import { AggregatedPrice } from '../infrastructure/types';
 import { LwwPriceRegister, RegionPriceRecord } from './price-crdt';
+import { propagateForHop, TraceHeaders } from './trace-context';
 
 export interface DriftReport {
   maxDriftPercent: number;
@@ -22,6 +23,23 @@ export class RegionPriceReplicator {
 
   getLatestPrices(): RegionPriceRecord[] {
     return this.register.latestAll();
+  }
+
+  /**
+   * Trace headers to attach to an outbound replication message for `asset`
+   * (issue #419). Continues the trace carried by the last inbound record for
+   * that asset, or starts a fresh one, and tags this region into `tracestate`.
+   */
+  outboundTraceHeaders(asset: string, inbound?: TraceHeaders): TraceHeaders {
+    const carried = inbound
+      ?? this.register
+        .byAsset(asset)
+        .filter((r) => r.source === 'remote' && r.traceparent)
+        .sort((a, b) => b.receivedAt - a.receivedAt)[0];
+    return propagateForHop(
+      carried ? { traceparent: carried.traceparent, tracestate: carried.tracestate } : undefined,
+      config.region.id,
+    );
   }
 
   getDriftReport(now = Date.now()): DriftReport {

--- a/services/aggregator/src/replication/trace-context.ts
+++ b/services/aggregator/src/replication/trace-context.ts
@@ -1,0 +1,81 @@
+/**
+ * W3C trace-context helpers for the cross-region replication bus (issue #419).
+ *
+ * The aggregator service does not depend on the OpenTelemetry SDK, so this is a
+ * dependency-free implementation of the `traceparent` / `tracestate` format
+ * (https://www.w3.org/TR/trace-context/). It lets replication messages carry the
+ * trace that started at source fetch through to the API read on the far side.
+ */
+
+const TRACEPARENT_RE = /^00-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/;
+
+export interface TraceContext {
+  traceId: string;
+  parentId: string;
+  sampled: boolean;
+  traceState?: string;
+}
+
+export type TraceHeaders = { traceparent?: string; tracestate?: string };
+
+function randomHex(bytes: number): string {
+  let out = '';
+  for (let i = 0; i < bytes; i += 1) {
+    out += Math.floor(Math.random() * 256).toString(16).padStart(2, '0');
+  }
+  return out;
+}
+
+/** Parse an inbound `traceparent` (+ optional `tracestate`). Returns null if malformed. */
+export function parseTraceparent(headers: TraceHeaders | undefined): TraceContext | null {
+  const match = headers?.traceparent?.match(TRACEPARENT_RE);
+  if (!match) return null;
+  const [, traceId, parentId, flags] = match;
+  if (/^0+$/.test(traceId) || /^0+$/.test(parentId)) return null;
+  return {
+    traceId,
+    parentId,
+    sampled: (parseInt(flags, 16) & 0x01) === 1,
+    traceState: headers?.tracestate,
+  };
+}
+
+/** Serialize a context back to headers for the next hop. */
+export function formatTraceparent(ctx: TraceContext): TraceHeaders {
+  const headers: TraceHeaders = {
+    traceparent: `00-${ctx.traceId}-${ctx.parentId}-${ctx.sampled ? '01' : '00'}`,
+  };
+  if (ctx.traceState) headers.tracestate = ctx.traceState;
+  return headers;
+}
+
+/** Start a fresh trace when a replication message arrives without one. */
+export function newTraceContext(sampled = true): TraceContext {
+  return { traceId: randomHex(16), parentId: randomHex(8), sampled };
+}
+
+/**
+ * Continue an inbound trace for an outbound replication message: keep the
+ * trace id, mint a new span/parent id for this hop, and prepend this region to
+ * `tracestate` so the cross-region path is visible.
+ */
+export function propagateForHop(
+  inbound: TraceHeaders | undefined,
+  regionId: string,
+): TraceHeaders {
+  const ctx = parseTraceparent(inbound) ?? newTraceContext();
+  const vendorEntry = `stellar-${regionId}=1`;
+  const priorState = ctx.traceState
+    ? ctx.traceState
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s && !s.startsWith(`stellar-${regionId}=`))
+        .join(',')
+    : '';
+  return formatTraceparent({
+    traceId: ctx.traceId,
+    parentId: randomHex(8),
+    sampled: ctx.sampled,
+    traceState: [vendorEntry, priorState].filter(Boolean).join(','),
+  });
+}

--- a/services/aggregator/tests/trace-context.test.ts
+++ b/services/aggregator/tests/trace-context.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseTraceparent,
+  formatTraceparent,
+  propagateForHop,
+  newTraceContext,
+} from '../src/replication/trace-context';
+
+const TP = '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01';
+
+describe('replication bus trace context (issue #419)', () => {
+  it('parses a valid W3C traceparent', () => {
+    const ctx = parseTraceparent({ traceparent: TP });
+    expect(ctx).not.toBeNull();
+    expect(ctx!.traceId).toBe('0af7651916cd43dd8448eb211c80319c');
+    expect(ctx!.parentId).toBe('b7ad6b7169203331');
+    expect(ctx!.sampled).toBe(true);
+  });
+
+  it('rejects malformed or all-zero ids', () => {
+    expect(parseTraceparent({ traceparent: 'garbage' })).toBeNull();
+    expect(parseTraceparent({ traceparent: '00-' + '0'.repeat(32) + '-b7ad6b7169203331-01' })).toBeNull();
+    expect(parseTraceparent(undefined)).toBeNull();
+  });
+
+  it('round-trips through format', () => {
+    const ctx = parseTraceparent({ traceparent: TP })!;
+    expect(formatTraceparent(ctx).traceparent).toBe(TP);
+  });
+
+  it('keeps the trace id across a hop but changes the span id', () => {
+    const next = propagateForHop({ traceparent: TP }, 'eu-west');
+    const parsed = parseTraceparent(next)!;
+    expect(parsed.traceId).toBe('0af7651916cd43dd8448eb211c80319c');
+    expect(parsed.parentId).not.toBe('b7ad6b7169203331');
+    expect(next.tracestate).toContain('stellar-eu-west=1');
+  });
+
+  it('starts a fresh trace when no context is carried', () => {
+    const next = propagateForHop(undefined, 'us-east');
+    const parsed = parseTraceparent(next)!;
+    expect(parsed.traceId).toHaveLength(32);
+    expect(/^[0-9a-f]{32}$/.test(parsed.traceId)).toBe(true);
+  });
+
+  it('newTraceContext produces valid ids', () => {
+    const ctx = newTraceContext();
+    expect(ctx.traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(ctx.parentId).toMatch(/^[0-9a-f]{16}$/);
+  });
+});

--- a/verification/fixtures/price-correctness-cases.json
+++ b/verification/fixtures/price-correctness-cases.json
@@ -1,0 +1,42 @@
+{
+  "note": "Known-good aggregation cases for the price correctness validation suite (issue #420). `sources` are per-source prices in the same unit; `expectedMedian` is the correct aggregate after dropping outliers; `expectedOutliers` lists sources a correct implementation must exclude (deviation from the all-source median above `outlierDeviationPercent`).",
+  "medianTolerancePercent": 0.01,
+  "outlierDeviationPercent": 10,
+  "cases": [
+    {
+      "name": "odd count, tight cluster - BTC",
+      "asset": "BTC",
+      "sources": [{ "source": "a", "price": 42010.5 }, { "source": "b", "price": 42005.0 }, { "source": "c", "price": 42015.25 }],
+      "expectedMedian": 42010.5,
+      "expectedOutliers": []
+    },
+    {
+      "name": "even count - average of middle two - ETH",
+      "asset": "ETH",
+      "sources": [{ "source": "a", "price": 2200.0 }, { "source": "b", "price": 2202.0 }, { "source": "c", "price": 2204.0 }, { "source": "d", "price": 2206.0 }],
+      "expectedMedian": 2203.0,
+      "expectedOutliers": []
+    },
+    {
+      "name": "single obvious outlier is rejected - BTC",
+      "asset": "BTC",
+      "sources": [{ "source": "a", "price": 42000.0 }, { "source": "b", "price": 42010.0 }, { "source": "c", "price": 41995.0 }, { "source": "d", "price": 63000.0 }],
+      "expectedMedian": 42000.0,
+      "expectedOutliers": ["d"]
+    },
+    {
+      "name": "two-sided outliers - XLM",
+      "asset": "XLM",
+      "sources": [{ "source": "a", "price": 0.115 }, { "source": "b", "price": 0.116 }, { "source": "c", "price": 0.1155 }, { "source": "d", "price": 0.05 }, { "source": "e", "price": 0.30 }],
+      "expectedMedian": 0.1155,
+      "expectedOutliers": ["d", "e"]
+    },
+    {
+      "name": "minimal quorum of two sources - USDC",
+      "asset": "USDC",
+      "sources": [{ "source": "a", "price": 1.0 }, { "source": "b", "price": 1.0009 }],
+      "expectedMedian": 1.00045,
+      "expectedOutliers": []
+    }
+  ]
+}


### PR DESCRIPTION
Resolves four observability/data hardening issues for launch readiness.

## #418 — Cost dashboards and budget alerts
- `docs/dashboards/cost-budget.json` — Grafana dashboard visualizing the requested-capacity cost model: total run rate with static warning ($24 / 80%) and exceeded ($30 / 100%) threshold lines, plus `stellar_oracle:requested_monthly_cost_usd_by_service_team` broken out per service and owning team for chargeback.
- `monitoring/alertmanager-cost-routes.yaml` — routing for `StellarOracleCostBudgetWarning` (→ Slack) and `StellarOracleCostBudgetExceeded` (→ Slack + PagerDuty), with `amtool config routes test` commands to confirm routing without waiting for a breach.
- `config/cost-invoices.json` + `scripts/reconcile-cost-invoices.mjs` (`npm run cost:reconcile`) — monthly reconciliation of the modeled run rate against the real provider invoice, per service, with a `--check` mode that fails when variance exceeds tolerance (default 15%).
- Runbook: `docs/runbooks/cost-budget-observability.md`.

## #421 — Historical backfill and gap detection
- `api/scripts/detect-history-gaps.ts` (`npm run history:gaps`) — scans `price_history` per asset, flags intervals longer than the expected cadence, exits non-zero when a gap exceeds `HISTORY_GAP_ALERT_SEC` (default 15m). JSON and human output.
- `api/scripts/backfill-history.ts` (`npm run history:backfill`) — replays source `history-<asset>.json` snapshots into `price_history`, idempotent via the `(asset, source, timestamp)` unique index, scopable with `--asset/--from/--to`.
- `.github/workflows/history-gap-detection.yml` — hourly run that opens a `data`/`alert` issue with the offending window on threshold breach.
- Runbook: `docs/runbooks/history-backfill-and-gap-detection.md`.

## #419 — Cross-region distributed tracing propagation
- `api/src/observability/trace-propagation.ts` — transport-agnostic W3C context inject/extract for the replication bus, a replication-span helper recording `region.source`/`region.target`/`bus_transit_ms`, and per-stage latency attributes.
- `services/aggregator/src/replication/trace-context.ts` — dependency-free `traceparent`/`tracestate` parse/format (the aggregator has no OTel SDK); `propagateForHop` keeps the trace id across a hop and tags the region into `tracestate`.
- `RegionPriceRecord` gains optional `traceparent`/`tracestate`; `RegionPriceReplicator.outboundTraceHeaders(asset)` continues the inbound trace onto the next hop.
- `docs/dashboards/cross-region-tracing.json` — per-stage and per-region-pair p95 latency breakdown, end-to-end trace duration, and traces missing a replication span.
- Verification (source fetch → aggregation → replication → API read) documented in `docs/runbooks/cross-region-tracing.md`; round-trip unit tests in `services/aggregator/tests/trace-context.test.ts`.

## #420 — Price correctness validation suite
- `scripts/validate-price-correctness.mjs` (`npm run validate:prices`) — replays known-good cases (`verification/fixtures/price-correctness-cases.json`) through the reference median + deviation-from-median outlier logic and asserts: median correctness within tolerance, exact expected-outlier rejection, and robustness against an injected 100× outlier.
- Added a `price-correctness` job to `.github/workflows/ci.yml`, so it runs on every push/PR to `main`/`develop` (i.e. every aggregator change).
- Runbook: `docs/runbooks/price-correctness-validation.md`.

## Verification
- `npm run validate:prices` — passes (5 cases, 15 checks).
- `npm run cost:reconcile -- --check` — passes.
- `npm run cost:check` — still green.

closes #418
closes #421
closes #419
closes #420