### PR TITLE
Fix/perf 430 433

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,7 @@ jobs:
           BENCHMARK_BASE_URL: http://localhost:3000
           BENCHMARK_THRESHOLD_PCT: '20'
           BENCHMARK_ITERATIONS: '20'
+          BENCHMARK_TARGET_TPS: '100000'
 
       - name: Upload benchmark results
         if: always()

--- a/api/src/observability/metrics.ts
+++ b/api/src/observability/metrics.ts
@@ -214,6 +214,14 @@ export const rateLimitRedisLatency = new client.Histogram({
 });
 register.registerMetric(rateLimitRedisLatency);
 
+export const pipelineStageLatencyMs = new client.Histogram({
+  name: 'pipeline_stage_latency_ms',
+  help: 'Latency budget for each stage of the price pipeline in milliseconds',
+  labelNames: ['stage', 'status'],
+  buckets: [1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000],
+});
+register.registerMetric(pipelineStageLatencyMs);
+
 export function metricsMiddleware(req: Request, res: Response, next: NextFunction): void {
   const end = httpRequestDuration.startTimer();
   res.on('finish', () => {

--- a/api/src/observability/request-logger.ts
+++ b/api/src/observability/request-logger.ts
@@ -1,7 +1,10 @@
 import { Request, Response, NextFunction } from 'express';
 import { logger } from './logger';
+import { pipelineStageLatencyMs } from './metrics';
 
-export function requestLogger(req: Request, _res: Response, next: NextFunction): void {
+export function requestLogger(req: Request, res: Response, next: NextFunction): void {
+  const startedAt = Date.now();
+
   logger.info(`${req.method} ${req.path}`, {
     requestId: (req as any).requestId,
     traceId: (req as any).traceId,
@@ -9,5 +12,12 @@ export function requestLogger(req: Request, _res: Response, next: NextFunction):
     query: req.query,
     ip: req.ip,
   });
+
+  res.on('finish', () => {
+    const durationMs = Date.now() - startedAt;
+    const status = res.statusCode >= 500 ? 'error' : 'ok';
+    pipelineStageLatencyMs.observe({ stage: 'api_serve', status }, durationMs);
+  });
+
   next();
 }

--- a/k8s/base/aggregator/hpa.yaml
+++ b/k8s/base/aggregator/hpa.yaml
@@ -9,6 +9,23 @@ spec:
     name: aggregator
   minReplicas: 2
   maxReplicas: 5
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 30
+        - type: Pods
+          value: 1
+          periodSeconds: 30
+      selectPolicy: Max
+    scaleDown:
+      stabilizationWindowSeconds: 180
+      policies:
+        - type: Percent
+          value: 10
+          periodSeconds: 60
   metrics:
     - type: Resource
       resource:

--- a/k8s/base/api/hpa.yaml
+++ b/k8s/base/api/hpa.yaml
@@ -9,6 +9,23 @@ spec:
     name: api-stable
   minReplicas: 2
   maxReplicas: 6
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 30
+        - type: Pods
+          value: 1
+          periodSeconds: 30
+      selectPolicy: Max
+    scaleDown:
+      stabilizationWindowSeconds: 180
+      policies:
+        - type: Percent
+          value: 10
+          periodSeconds: 60
   metrics:
     - type: Resource
       resource:

--- a/scripts/benchmark.js
+++ b/scripts/benchmark.js
@@ -29,6 +29,7 @@ const path = require('path');
 const BASE_URL = process.env.BENCHMARK_BASE_URL || 'http://localhost:3000';
 const THRESHOLD_PCT = parseFloat(process.env.BENCHMARK_THRESHOLD_PCT || '20');
 const ITERATIONS = parseInt(process.env.BENCHMARK_ITERATIONS || '20', 10);
+const THROUGHPUT_TARGET_RPS = parseFloat(process.env.BENCHMARK_TARGET_TPS || '0');
 const BASELINE_PATH = path.join(__dirname, 'benchmark-baseline.json');
 const UPDATE_BASELINE = process.argv.includes('--update-baseline');
 
@@ -112,10 +113,12 @@ async function runBenchmark() {
       continue;
     }
 
-    results[key] = { ...stats(durations), errors };
+    const totalDurationMs = durations.reduce((sum, current) => sum + current, 0);
+    const throughputRps = durations.length > 0 && totalDurationMs > 0 ? durations.length / (totalDurationMs / 1000) : 0;
+    results[key] = { ...stats(durations), errors, throughputRps };
     const s = results[key];
     console.log(
-      `  ${key.padEnd(40)} p50=${s.p50}ms  p95=${s.p95}ms  p99=${s.p99}ms  err=${errors}`
+      `  ${key.padEnd(40)} p50=${s.p50}ms  p95=${s.p95}ms  p99=${s.p99}ms  rps=${throughputRps.toFixed(1)}  err=${errors}`
     );
   }
 
@@ -131,6 +134,15 @@ async function runBenchmark() {
   // ---------------------------------------------------------------------------
   // Regression check
   // ---------------------------------------------------------------------------
+  if (THROUGHPUT_TARGET_RPS > 0) {
+    const maxRps = Object.values(results).reduce((max, entry) => Math.max(max, Number(entry.throughputRps || 0)), 0);
+    if (maxRps < THROUGHPUT_TARGET_RPS) {
+      console.error(`\nBenchmark throughput ${maxRps.toFixed(1)} rps is below target ${THROUGHPUT_TARGET_RPS} rps.`);
+      process.exit(1);
+    }
+    console.log(`\nThroughput checkpoint: ${maxRps.toFixed(1)} rps (target ${THROUGHPUT_TARGET_RPS} rps)`);
+  }
+
   if (!fs.existsSync(BASELINE_PATH)) {
     console.warn(
       `\nNo baseline found at ${BASELINE_PATH}. ` +

--- a/services/aggregator/src/contract-publishing/publisher.ts
+++ b/services/aggregator/src/contract-publishing/publisher.ts
@@ -10,6 +10,7 @@ import {
 import { config } from '../infrastructure/config';
 import { logger } from '../observability/logger';
 import { AggregatedPrice } from '../infrastructure/types';
+import { contractSubmissionGas, contractSubmissionGasTotal } from '../observability/metrics';
 import { SubmissionRetryQueue } from './retry-queue';
 
 interface ContractCallLog {
@@ -161,6 +162,11 @@ export class ContractPublisher {
       const sendResponse: any = await this.server.sendTransaction(tx);
       const actualFee = sendResponse?.fee ?? simulationFee;
       const feeNum = parseInt(String(actualFee), 10);
+
+      if (!Number.isNaN(feeNum)) {
+        contractSubmissionGas.observe({ function: fnName, asset, status: 'success' }, feeNum);
+        contractSubmissionGasTotal.inc({ function: fnName, asset, status: 'success' }, feeNum);
+      }
 
       emitContractLog({
         txHash,

--- a/services/aggregator/src/index.ts
+++ b/services/aggregator/src/index.ts
@@ -9,7 +9,7 @@ import { appendUptimeSnapshot } from './persistence/uptime-history';
 import { FileArchivalService } from './persistence/file-archival';
 import { RegionPriceReplicator } from './replication/region-price-replicator';
 import { RegionQuarantineManager } from './replication/region-quarantine';
-import { oracleSourceUptimePercent, onChainPriceStalenessSeconds, onChainHeartbeatAlertsTotal } from './observability/metrics';
+import { oracleSourceUptimePercent, onChainPriceStalenessSeconds, onChainHeartbeatAlertsTotal, pipelineStageLatencyMs } from './observability/metrics';
 import { DatabaseClient } from './persistence/database';
 import { BaseSource } from './oracle-sources/base';
 import { WebSocketServer } from './infrastructure/ws-server';
@@ -62,6 +62,7 @@ let pollSources: BaseSource[] = [];
 async function poll(): Promise<AggregatedPrice[]> {
   const sources: BaseSource[] = pollSources;
   const sourcePricesByAsset: Map<string, { source: string; price: string }[]> = new Map();
+  const sourceFetchStarted = performance.now();
 
   for (const source of sources) {
     const prices = await source.fetchAll(config.assets);
@@ -106,8 +107,15 @@ async function poll(): Promise<AggregatedPrice[]> {
     }
   }
 
+  pipelineStageLatencyMs.observe({ stage: 'source_fetch', status: 'ok' }, performance.now() - sourceFetchStarted);
+
+  const aggregationStarted = performance.now();
   const aggregated = aggregator.getAllPrices();
+  pipelineStageLatencyMs.observe({ stage: 'aggregation', status: 'ok' }, performance.now() - aggregationStarted);
+
+  const replicationStarted = performance.now();
   regionReplicator.mergeLocalPrices(aggregated);
+  pipelineStageLatencyMs.observe({ stage: 'replication', status: 'ok' }, performance.now() - replicationStarted);
   const allSourceNames = ['chainlink', 'redstone', 'band', 'reflector'];
   for (const ap of aggregated) {
     // Publish PriceAggregatedEvent
@@ -177,7 +185,9 @@ async function poll(): Promise<AggregatedPrice[]> {
 
   if (config.soroban.contractId) {
     const publisher = new ContractPublisher();
+    const publishStarted = performance.now();
     await publisher.publishAggregated(aggregated);
+    pipelineStageLatencyMs.observe({ stage: 'publish', status: 'ok' }, performance.now() - publishStarted);
 
     // Publish PricePublishedEvent
     eventBus.publish({

--- a/services/aggregator/src/observability/metrics.ts
+++ b/services/aggregator/src/observability/metrics.ts
@@ -107,4 +107,19 @@ export const onChainHeartbeatAlertsTotal = new client.Counter({
   registers: [register],
 });
 
+export const contractSubmissionGas = new client.Histogram({
+  name: 'contract_submission_gas',
+  help: 'Gas used by Soroban contract submissions in stroops',
+  labelNames: ['function', 'asset', 'status'],
+  buckets: [1000, 5000, 10000, 50000, 100000, 500000, 1000000, 5000000, 10000000],
+  registers: [register],
+});
+
+export const contractSubmissionGasTotal = new client.Counter({
+  name: 'contract_submission_gas_total',
+  help: 'Total gas used by Soroban contract submissions',
+  labelNames: ['function', 'asset', 'status'],
+  registers: [register],
+});
+
 export { register };

--- a/services/aggregator/src/observability/metrics.ts
+++ b/services/aggregator/src/observability/metrics.ts
@@ -122,4 +122,12 @@ export const contractSubmissionGasTotal = new client.Counter({
   registers: [register],
 });
 
+export const pipelineStageLatencyMs = new client.Histogram({
+  name: 'pipeline_stage_latency_ms',
+  help: 'Latency budget for each stage of the price pipeline in milliseconds',
+  labelNames: ['stage', 'status'],
+  buckets: [1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000],
+  registers: [register],
+});
+
 export { register };


### PR DESCRIPTION
## Summary

This PR addresses the four performance issues for the oracle stack:

- autoscaling warm-up / scale-up tuning
- per-submission gas metric export
- throughput regression guard in CI
- stage-by-stage latency budget tracking

## Changes

### #430: autoscaling warm-up and scale-up tuning
- tightened HPA `scaleUp` behavior to reduce cold-start latency risk
- added explicit stabilization windows and faster scale-up policy settings for the API and aggregator
- kept scale-down behavior conservative to avoid oscillation

### #431: gas cost monitoring and optimization
- exported per-submission gas metrics from the Soroban publisher
- recorded gas usage by contract function / asset / status in Prometheus histograms and counters
- kept the existing gas alert threshold intact while adding metric visibility for trend monitoring

### #432: throughput benchmarking against the 100k TPS target
- extended the benchmark script to emit throughput data alongside latency statistics
- added a CI checkpoint that fails when throughput falls below the configured target
- kept the change minimal and focused on regression detection rather than introducing a new benchmark framework

### #433: end-to-end latency budget analysis
- added stage-level latency metrics for:
  - source fetch
  - aggregation
  - replication
  - publish
  - API serve
- exposed the measurements as Prometheus histograms so p99 regressions can be localized quickly by stage

## Validation

- Ran targeted TypeScript validation for the changed services:
  - `cd services/aggregator && npx tsc --noEmit`
  - `cd api && npx tsc --noEmit`

## Related issues

closes #430
closes #431
closes #432
closes #433
