### PR TITLE
Fix/issues 422 425

### DIFF
--- a/api/src/price-serving/pagination.ts
+++ b/api/src/price-serving/pagination.ts
@@ -42,14 +42,15 @@ export function buildCursorMeta(
   limit: number,
   timestampField: string,
 ): CursorPaginationMeta {
-  const hasNextPage = items.length === limit;
-  const lastItem = items[items.length - 1];
+  const hasNextPage = items.length > limit;
+  const pageItems = hasNextPage ? items.slice(0, limit) : items;
+  const lastItem = pageItems[pageItems.length - 1];
   const nextCursor =
     hasNextPage && lastItem
       ? encodeCursor({ ts: lastItem[timestampField], dir: 'asc' })
       : null;
 
-  return { type: 'cursor', limit, count: items.length, hasNextPage, nextCursor };
+  return { type: 'cursor', limit, count: pageItems.length, hasNextPage, nextCursor };
 }
 
 // ── Offset pagination helpers ─────────────────────────────────────────────────

--- a/api/src/price-serving/pagination.ts
+++ b/api/src/price-serving/pagination.ts
@@ -71,8 +71,8 @@ export function applyOffsetPagination<T>(
   limit: number,
 ): { items: T[]; meta: OffsetPaginationMeta } {
   const total = items.length;
-  const totalPages = Math.max(1, Math.ceil(total / limit));
-  const safePage = Math.min(page, totalPages);
+  const totalPages = total === 0 ? 0 : Math.ceil(total / limit);
+  const safePage = total === 0 ? 1 : Math.min(page, totalPages);
   const start = (safePage - 1) * limit;
   const paged = items.slice(start, start + limit);
 
@@ -84,8 +84,8 @@ export function applyOffsetPagination<T>(
       limit,
       total,
       totalPages,
-      hasNextPage: safePage < totalPages,
-      hasPrevPage: safePage > 1,
+      hasNextPage: totalPages > 0 && safePage < totalPages,
+      hasPrevPage: totalPages > 0 && safePage > 1,
     },
   };
 }

--- a/api/src/price-serving/price-store.ts
+++ b/api/src/price-serving/price-store.ts
@@ -87,6 +87,8 @@ export async function readPriceHistory(
   to?: number,
   limit = 100,
 ): Promise<HistoricalPriceEntry[]> {
+  if (from !== undefined && to !== undefined && from > to) return [];
+
   if (db && db.isInitialized()) {
     try {
       const history = await db.getHistoricalPrices(asset, from, to, limit);
@@ -125,6 +127,11 @@ export async function readPriceHistoryCursor(
   limit: number,
   to?: number,
 ): Promise<HistoricalPriceEntry[]> {
+  if (cursor) {
+    const decoded = decodeCursor(cursor);
+    if (decoded && to !== undefined && decoded.ts > to) return [];
+  }
+
   let afterTs: number | undefined;
   if (cursor) {
     const decoded = decodeCursor(cursor);

--- a/api/src/price-serving/price-store.ts
+++ b/api/src/price-serving/price-store.ts
@@ -134,7 +134,7 @@ export async function readPriceHistoryCursor(
   if (db && db.isInitialized()) {
     try {
       const from = afterTs !== undefined ? afterTs + 1 : undefined;
-      const history = await db.getHistoricalPrices(asset, from, to, limit);
+      const history = await db.getHistoricalPrices(asset, from, to, limit + 1);
       return history.map((h: any) => ({
         price: h.price as string,
         decimals: h.decimals as number,
@@ -154,7 +154,7 @@ export async function readPriceHistoryCursor(
     history.sort((a, b) => a.timestamp - b.timestamp);
     if (afterTs !== undefined) history = history.filter((h) => h.timestamp > afterTs!);
     if (to !== undefined) history = history.filter((h) => h.timestamp <= to);
-    return history.slice(0, limit);
+    return history.slice(0, limit + 1);
   } catch {
     return [];
   }

--- a/api/src/price-serving/v1.ts
+++ b/api/src/price-serving/v1.ts
@@ -216,12 +216,13 @@ router.get('/history/:asset', async (req: Request, res: Response) => {
   cacheMissTotal.inc();
 
   const history = await readPriceHistoryCursor(upperAsset, cursor, limit, to);
+  const page = history.length > limit ? history.slice(0, limit) : history;
   const pagination = buildCursorMeta(history, limit, 'timestamp');
 
   const response = {
     asset: upperAsset,
     to: to || null,
-    prices: history,
+    prices: page,
     pagination,
   };
 

--- a/api/src/price-serving/validation.ts
+++ b/api/src/price-serving/validation.ts
@@ -1,25 +1,43 @@
 import { z, ZodError } from 'zod';
 import { PAGINATION_DEFAULTS } from './pagination';
 
-const assetValidator = z.string().min(1).refine(
-  (val) => {
-    if (/^[A-Z0-9]{1,12}$/.test(val)) return true;
-    if (val.startsWith('C') && val.length === 56) return true;
-    return false;
-  },
-  { message: 'Invalid asset: must be a 1-12 character uppercase symbol (e.g. XLM, USDC) or a 56-character Soroban contract ID starting with C' }
+const normalizeAsset = (value: unknown): unknown => {
+  if (typeof value !== 'string') return value;
+  return value.trim().toUpperCase();
+};
+
+const assetValidator = z.preprocess(
+  normalizeAsset,
+  z.string().trim().min(1).refine(
+    (val) => {
+      if (/^[A-Z0-9]{1,12}$/.test(val)) return true;
+      if (val.startsWith('C') && val.length === 56) return true;
+      return false;
+    },
+    { message: 'Invalid asset: must be a 1-12 character uppercase symbol (e.g. XLM, USDC) or a 56-character Soroban contract ID starting with C' },
+  ),
 );
 
 export const AssetQuerySchema = z.object({
   asset: assetValidator.optional(),
 });
 
+const ensureValidTimeRange = (data: { from?: number; to?: number }, ctx: z.RefinementCtx) => {
+  if (data.from !== undefined && data.to !== undefined && data.from > data.to) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['to'],
+      message: 'to must be greater than or equal to from',
+    });
+  }
+};
+
 export const HistoryQuerySchema = z.object({
   asset: assetValidator,
   from: z.coerce.number().int().positive().optional().describe('Unix timestamp (seconds) for range start'),
   to: z.coerce.number().int().positive().optional().describe('Unix timestamp (seconds) for range end'),
   limit: z.coerce.number().int().min(1, 'limit must be at least 1').max(1000, 'limit cannot exceed 1000').default(100),
-});
+}).superRefine(ensureValidTimeRange);
 
 // Cursor-based pagination (history / time-series endpoints)
 export const CursorHistoryQuerySchema = z.object({
@@ -33,7 +51,7 @@ export const CursorHistoryQuerySchema = z.object({
     .default(PAGINATION_DEFAULTS.PAGE_SIZE),
   from: z.coerce.number().int().positive().optional().describe('Unix timestamp lower bound (ignored when cursor is provided)'),
   to: z.coerce.number().int().positive().optional().describe('Unix timestamp upper bound'),
-});
+}).superRefine(ensureValidTimeRange);
 
 // Offset-based pagination (sources, prices list)
 export const OffsetQuerySchema = z.object({


### PR DESCRIPTION
# Fix API validation and pagination edge cases

## Summary

This patch tightens the API validation and pagination behavior for price queries without broadening the existing surface area.

- Normalize asset input before validation so values are trimmed and uppercased consistently.
- Reject invalid time ranges early to avoid confusing history responses.
- Correct cursor pagination metadata so `hasNextPage` and follow-up cursors reflect the true page state.
- Prevent empty offset pagination from producing invalid page metadata.
- Guard history reads against malformed range inputs before hitting storage.

## Testing

- `cd api && npx vitest run tests/services.test.ts`

## Closes

- Closes #422
- Closes #423
- Closes #424
- Closes #425



Closes #422 
Closes #423
Closes #424
Closes #425 