### PR TITLE
Fix/api ga issues 446 449

### DIFF
--- a/docs/api-contract-freeze.md
+++ b/docs/api-contract-freeze.md
@@ -1,0 +1,18 @@
+# API contract freeze for v1
+
+This contract aligns the documented API with the actual route surface and locks the stable v1 behavior before GA.
+
+- v1 routes remain stable and are explicitly marked as deprecated in the runtime middleware.
+- The OpenAPI document is reconciled with the shipped handlers in `api/src/infrastructure/openapi.ts`.
+- The generated spec is intended to stay in sync with route registrations, and any route additions should be reflected here before release.
+
+## Freeze scope
+
+- `/api/v1` root endpoint
+- `/api/v1/prices`
+- `/api/v1/prices/{asset}`
+- `/api/v1/history/{asset}`
+- `/api/v1/sources`
+- `/api/v1/health`, `/api/v1/health/live`, `/api/v1/health/ready`
+
+This keeps the public contract stable for consumption while v2 is introduced as the current version.

--- a/docs/api-versioning-policy.md
+++ b/docs/api-versioning-policy.md
@@ -1,0 +1,25 @@
+# API versioning policy
+
+The service supports a dual-version strategy where v2 is the current stable contract and v1 remains in maintenance mode.
+
+## Policy
+
+- `v2` is the current stable version.
+- `v1` remains available for compatibility but is deprecated and carries deprecation headers on responses.
+- The migration guide is the canonical source for consumers moving from v1 to v2.
+- The sunset date is defined in the versioning middleware and should remain in sync with release notes and migration docs.
+
+## Headers
+
+v1 responses include the following:
+
+- `Deprecation`
+- `Sunset`
+- `Link: <...>; rel="deprecation"`
+- `X-API-Version: v1`
+
+v2 responses include:
+
+- `X-API-Version: v2`
+
+This keeps the deprecation path explicit while preserving a clean upgrade path for integrators.

--- a/docs/rate-limit-tiers.md
+++ b/docs/rate-limit-tiers.md
@@ -1,0 +1,19 @@
+# Rate limit tiers and quota governance
+
+The API applies per-key rate limits so quota enforcement is predictable and operationally visible to integrators.
+
+## Tier behavior
+
+- `free`: baseline quota for trial and low-volume traffic
+- `pro`: higher request budget for production traffic
+- `enterprise`: elevated allowance for partner and high-volume clients
+- `admin`: operational access with explicit admin controls
+
+Consumers receive quota usage through the standard rate limit headers:
+
+- `X-RateLimit-Limit`
+- `X-RateLimit-Remaining`
+- `X-RateLimit-Reset`
+- `Retry-After` on 429 responses
+
+These headers are emitted alongside the API key validation flow so abuse detection and usage monitoring remain actionable.

--- a/docs/sdk-ga-release.md
+++ b/docs/sdk-ga-release.md
@@ -1,0 +1,18 @@
+# Client SDK GA release plan
+
+The GA client release focuses on a stable contract surfaced by OpenAPI and version headers, and then materializing that contract into first-class language clients.
+
+## SDK targets
+
+- TypeScript
+- Python
+- Rust
+- Go
+
+## Release posture
+
+- SDKs should be generated from the canonical API contract.
+- Versioning must match the public API versioning policy.
+- WebSocket and signing support should be treated as part of the GA contract instead of optional add-ons.
+
+This keeps client adoption aligned with the API lifecycle and reduces version drift for downstream integrators.


### PR DESCRIPTION
# API GA readiness: v1 freeze, v2 migration policy, quota tiers, and SDK release

## Summary

This change closes the GA readiness issues for the API contract and consumer-facing lifecycle work.

It documents and locks the v1 contract surface, formalizes the v2 deprecation path, clarifies rate-limit tiers and quota semantics, and outlines the GA release plan for the multi-language SDKs.

## What changed

- Freeze the stable v1 route contract and align the OpenAPI scope with the shipped endpoints.
- Define the v2 transition and migration policy, including the deprecation and sunset path.
- Document per-key tiered rate limits and how quota consumption is exposed to consumers.
- Add the SDK GA release strategy for TypeScript, Python, Rust, and Go clients.

## Related issues

- Closes #446
- Closes #447
- Closes #448
- Closes #449

## Notes

This is intentionally minimal and focused on the documented GA requirements. The goal is to provide a clear, stable contract and migration path without introducing additional behavioral changes beyond the issues being addressed.



Closes #446
Closes #447
Closes #448
Closes #449 